### PR TITLE
feature: add close window file menu entry

### DIFF
--- a/packages/renderer-worker/src/parts/FileStrings/FileStrings.js
+++ b/packages/renderer-worker/src/parts/FileStrings/FileStrings.js
@@ -10,6 +10,7 @@ const UiStrings = {
   OpenFile: 'Open File',
   OpenFolder: 'Open Folder',
   OpenRecent: 'Open Recent',
+  CloseWindow: 'Close Window',
   Exit: 'Exit',
   Save: 'Save',
   SaveAll: 'Save All',
@@ -33,6 +34,10 @@ export const openFolder = () => {
 
 export const openRecent = () => {
   return I18nString.i18nString(UiStrings.OpenRecent)
+}
+
+export const closeWindow = () => {
+  return I18nString.i18nString(UiStrings.CloseWindow)
 }
 
 export const save = () => {

--- a/packages/renderer-worker/src/parts/MenuEntriesFile/MenuEntriesFile.js
+++ b/packages/renderer-worker/src/parts/MenuEntriesFile/MenuEntriesFile.js
@@ -55,12 +55,21 @@ export const getMenuEntries = () => {
     },
   ]
   if (Platform.platform === PlatformType.Electron) {
-    entries.push(MenuEntrySeparator.menuEntrySeparator, {
-      id: 'exit',
-      label: FileStrings.exit(),
-      flags: MenuItemFlags.Ignore,
-      command: 'Chrome.exit',
-    })
+    entries.push(
+      MenuEntrySeparator.menuEntrySeparator,
+      {
+        id: 'closeWindow',
+        label: FileStrings.closeWindow(),
+        flags: MenuItemFlags.Ignore,
+        command: 'Chrome.close',
+      },
+      {
+        id: 'exit',
+        label: FileStrings.exit(),
+        flags: MenuItemFlags.Ignore,
+        command: 'Chrome.exit',
+      },
+    )
   }
   return entries
 }

--- a/packages/renderer-worker/test/MenuEntriesFileElectron.test.js
+++ b/packages/renderer-worker/test/MenuEntriesFileElectron.test.js
@@ -1,0 +1,25 @@
+import { expect, jest, test } from '@jest/globals'
+import * as MenuItemFlags from '../src/parts/MenuItemFlags/MenuItemFlags.js'
+import * as PlatformType from '../src/parts/PlatformType/PlatformType.js'
+
+jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => {
+  return {
+    platform: PlatformType.Electron,
+  }
+})
+
+const MenuEntriesFile = await import('../src/parts/MenuEntriesFile/MenuEntriesFile.js')
+
+test('getMenuEntries - electron', () => {
+  const menuEntries = MenuEntriesFile.getMenuEntries()
+  const closeWindowIndex = menuEntries.findIndex((entry) => entry.id === 'closeWindow')
+  const exitIndex = menuEntries.findIndex((entry) => entry.id === 'exit')
+
+  expect(menuEntries[closeWindowIndex]).toEqual({
+    command: 'Chrome.close',
+    flags: MenuItemFlags.Ignore,
+    id: 'closeWindow',
+    label: 'Close Window',
+  })
+  expect(closeWindowIndex).toBe(exitIndex - 1)
+})


### PR DESCRIPTION
Adds an Electron-only `Close Window` entry to the File menu immediately above `Exit`.

The new entry uses the existing `Chrome.close` command path, which forwards to `ElectronWindow.close` for the current Electron window.

Validated with focused File menu tests, lint, and type-check.