### PR TITLE
fix: reopen csv files as text editor

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletMain/ViewletMain.js
+++ b/packages/renderer-worker/src/parts/ViewletMain/ViewletMain.js
@@ -717,7 +717,7 @@ const getWebViews = async (uri) => {
   return [
     {
       id: 'editor',
-      label: 'Editor',
+      label: 'Text Editor',
     },
     ...quickPickEntries,
   ]
@@ -726,10 +726,10 @@ const getWebViews = async (uri) => {
 export const reopenEditorWith = async (state) => {
   // TODO
   // 1. get current editor type
-  const { groups } = state
-  const group = groups[0]
-  const { editors } = group
-  const editor = editors[0]
+  const { groups, activeGroupIndex } = state
+  const group = groups[activeGroupIndex]
+  const { editors, activeIndex } = group
+  const editor = editors[activeIndex]
   // 2. get webviews that exist for editor type
   const webViews = await getWebViews(editor.uri)
   // 3. open quickpick, asking to select an editor type

--- a/packages/renderer-worker/src/parts/ViewletMain/ViewletMainOpenUri.ts
+++ b/packages/renderer-worker/src/parts/ViewletMain/ViewletMainOpenUri.ts
@@ -10,7 +10,7 @@ import * as ViewletModule from '../ViewletModule/ViewletModule.js'
 import * as ViewletStates from '../ViewletStates/ViewletStates.js'
 import * as ViewletMainFocusIndex from './ViewletMainFocusIndex.js'
 
-export const openUri = async (state, uri, focus = true, { preview = false, ...context } = {}) => {
+export const openUri = async (state, uri, focus = true, { preview = false, ...context }: any = {}) => {
   Assert.object(state)
   Assert.string(uri)
   const { tabFontWeight, tabFontSize, tabFontFamily, tabLetterSpacing, groups, activeGroupIndex, tabHeight } = state
@@ -73,6 +73,7 @@ export const openUri = async (state, uri, focus = true, { preview = false, ...co
     tabWidth,
     flags: TabFlags.Preview,
     moduleId,
+    opener: context.opener,
   }
   const newEditors = [...activeGroup.editors, newEditor]
   const newActiveIndex = newEditors.length - 1

--- a/packages/renderer-worker/src/parts/ViewletMap/ViewletMap.js
+++ b/packages/renderer-worker/src/parts/ViewletMap/ViewletMap.js
@@ -14,6 +14,9 @@ const mapExtToEditorType = {
 }
 
 export const getModuleId = async (uri, opener) => {
+  if (opener === 'editor') {
+    return ViewletModuleId.EditorText
+  }
   if (uri === 'app://keybindings') {
     return ViewletModuleId.KeyBindings
   }

--- a/packages/renderer-worker/test/ViewletMainReopenEditorWith.test.js
+++ b/packages/renderer-worker/test/ViewletMainReopenEditorWith.test.js
@@ -1,0 +1,76 @@
+// @ts-nocheck
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+jest.unstable_mockModule('../src/parts/Command/Command.js', () => {
+  return {
+    execute: jest.fn((command, ...args) => {
+      if (command === 'QuickPick.showCustom') {
+        const resolve = args[1]
+        resolve({
+          id: 'editor',
+        })
+      }
+    }),
+  }
+})
+
+jest.unstable_mockModule('../src/parts/GetWebViews/GetWebViews.ts', () => {
+  return {
+    getWebViews() {
+      return [
+        {
+          id: 'builtin.csv-viewer',
+          name: 'CSV Viewer',
+          selector: ['.csv'],
+        },
+      ]
+    },
+  }
+})
+
+const Command = await import('../src/parts/Command/Command.js')
+const ViewletMain = await import('../src/parts/ViewletMain/ViewletMain.js')
+
+test('reopenEditorWith - reopens active csv editor as text editor', async () => {
+  const state = {
+    activeGroupIndex: 0,
+    groups: [
+      {
+        activeIndex: 1,
+        editors: [
+          {
+            uri: '/tmp/one.txt',
+          },
+          {
+            uri: '/tmp/test.csv',
+          },
+        ],
+      },
+    ],
+  }
+
+  await ViewletMain.reopenEditorWith(state)
+
+  expect(Command.execute).toHaveBeenNthCalledWith(
+    1,
+    'QuickPick.showCustom',
+    [
+      {
+        id: 'editor',
+        label: 'Text Editor',
+      },
+      {
+        id: 'builtin.csv-viewer',
+        label: 'CSV Viewer',
+      },
+    ],
+    expect.any(Function),
+  )
+  expect(Command.execute).toHaveBeenNthCalledWith(2, 'Main.openUri', '/tmp/test.csv', true, {
+    opener: 'editor',
+  })
+})

--- a/packages/renderer-worker/test/ViewletMapWebViews.test.js
+++ b/packages/renderer-worker/test/ViewletMapWebViews.test.js
@@ -1,0 +1,27 @@
+// @ts-nocheck
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/GetWebViews/GetWebViews.ts', () => {
+  return {
+    getWebViews() {
+      return [
+        {
+          id: 'builtin.csv-viewer',
+          selector: ['.csv'],
+        },
+      ]
+    },
+  }
+})
+
+const ViewletMap = await import('../src/parts/ViewletMap/ViewletMap.js')
+const ViewletModuleId = await import('../src/parts/ViewletModuleId/ViewletModuleId.js')
+
+test('csv - default opener uses webview', async () => {
+  expect(await ViewletMap.getModuleId('/test/file.csv')).toBe(ViewletModuleId.WebView)
+})
+
+test('csv - editor opener uses text editor', async () => {
+  expect(await ViewletMap.getModuleId('/test/file.csv', 'editor')).toBe(ViewletModuleId.EditorText)
+})
+


### PR DESCRIPTION
## Summary
- make the explicit Text Editor opener bypass CSV webview association
- reopen the active editor instead of the first editor when using Reopen Editor With
- add focused regressions for CSV webview/text-editor selection