### PR TITLE
fix: focus editor after opening file

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletMain/ViewletMainOpenUri.ts
+++ b/packages/renderer-worker/src/parts/ViewletMain/ViewletMainOpenUri.ts
@@ -10,6 +10,30 @@ import * as ViewletModule from '../ViewletModule/ViewletModule.js'
 import * as ViewletStates from '../ViewletStates/ViewletStates.js'
 import * as ViewletMainFocusIndex from './ViewletMainFocusIndex.js'
 
+const isFocusCommand = (command, uid) => {
+  return (
+    (command[0] === 'Viewlet.send' && command[1] === uid && command[2] === 'setFocused') ||
+    (command[0] === 'Viewlet.focusSelector' && command[1] === uid) ||
+    (command[0] === 'Viewlet.focusElementByName' && command[1] === uid)
+  )
+}
+
+export const getCommandsWithDeferredFocus = (commands, uid) => {
+  const focusCommands: any[] = []
+  const otherCommands: any[] = []
+  for (const command of commands) {
+    if (isFocusCommand(command, uid)) {
+      focusCommands.push(command)
+    } else {
+      otherCommands.push(command)
+    }
+  }
+  return {
+    focusCommands,
+    otherCommands,
+  }
+}
+
 export const openUri = async (state, uri, focus = true, { preview = false, ...context }: any = {}) => {
   Assert.object(state)
   Assert.string(uri)
@@ -93,17 +117,19 @@ export const openUri = async (state, uri, focus = true, { preview = false, ...co
   }
   // @ts-ignore
   const commands = await ViewletManager.load(instance, focus)
-  commands.push(['Viewlet.setBounds', instanceUid, activeGroup.x, tabHeight, activeGroup.width, contentHeight])
+  const { focusCommands, otherCommands } = focus ? getCommandsWithDeferredFocus(commands, instanceUid) : { focusCommands: [], otherCommands: commands }
+  otherCommands.push(['Viewlet.setBounds', instanceUid, activeGroup.x, tabHeight, activeGroup.width, contentHeight])
   let tabsUid = state.tabsUid
   if (tabsUid === -1) {
     tabsUid = Id.create()
   }
   if (disposeCommands) {
-    commands.push(...disposeCommands)
+    otherCommands.push(...disposeCommands)
   }
-  commands.push(['Viewlet.append', state.uid, instanceUid])
+  otherCommands.push(['Viewlet.append', state.uid, instanceUid])
+  otherCommands.push(...focusCommands)
   if (focus) {
-    commands.push(['Viewlet.focus', instanceUid])
+    otherCommands.push(['Viewlet.focus', instanceUid])
   }
   const latestState = ViewletStates.getState(state.uid)
   const latestPendingUid = latestState.pendingUid
@@ -116,7 +142,7 @@ export const openUri = async (state, uri, focus = true, { preview = false, ...co
   if (!ViewletStates.hasInstance(instanceUid)) {
     return {
       newState: state,
-      commands,
+      commands: otherCommands,
     }
   }
   return {
@@ -125,6 +151,6 @@ export const openUri = async (state, uri, focus = true, { preview = false, ...co
       tabsUid,
       groups: newGroups,
     },
-    commands,
+    commands: otherCommands,
   }
 }

--- a/packages/renderer-worker/test/ViewletMain.test.js
+++ b/packages/renderer-worker/test/ViewletMain.test.js
@@ -54,6 +54,7 @@ const RendererProcess = await import('../src/parts/RendererProcess/RendererProce
 const SharedProcess = await import('../src/parts/SharedProcess/SharedProcess.js')
 const ViewletStates = await import('../src/parts/ViewletStates/ViewletStates.js')
 const ViewletMain = await import('../src/parts/ViewletMain/ViewletMain.js')
+const ViewletMainOpenUri = await import('../src/parts/ViewletMain/ViewletMainOpenUri.ts')
 
 test('create', () => {
   const state = ViewletMain.create(1)
@@ -108,6 +109,29 @@ test('loadContent - one restored editor', async () => {
       },
     ],
   })
+})
+
+test('openUri - defers editor focus commands', () => {
+  const { otherCommands, focusCommands } = ViewletMainOpenUri.getCommandsWithDeferredFocus(
+    [
+      ['Viewlet.createFunctionalRoot', 'EditorText', 2],
+      ['Viewlet.send', 2, 'setText', []],
+      ['Viewlet.send', 2, 'setFocused', true],
+      ['Viewlet.focusSelector', 2, '.EditorInput textarea'],
+      ['Viewlet.send', 3, 'setFocused', true],
+    ],
+    2,
+  )
+
+  expect(otherCommands).toEqual([
+    ['Viewlet.createFunctionalRoot', 'EditorText', 2],
+    ['Viewlet.send', 2, 'setText', []],
+    ['Viewlet.send', 3, 'setFocused', true],
+  ])
+  expect(focusCommands).toEqual([
+    ['Viewlet.send', 2, 'setFocused', true],
+    ['Viewlet.focusSelector', 2, '.EditorInput textarea'],
+  ])
 })
 
 // TODO test is flaky


### PR DESCRIPTION
## Summary
- defer editor focus commands until after the newly opened editor is appended
- add regression coverage for focus command ordering