### PR TITLE
fix: expose workspace home dir

### DIFF
--- a/packages/renderer-worker/src/parts/Workspace/Workspace.ipc.js
+++ b/packages/renderer-worker/src/parts/Workspace/Workspace.ipc.js
@@ -4,6 +4,7 @@ export const name = 'Workspace'
 
 export const Commands = {
   close: Workspace.close,
+  getHomeDir: Workspace.getHomeDir,
   getPath: Workspace.getPath,
   getUri: Workspace.getUri,
   hydrate: Workspace.hydrate,


### PR DESCRIPTION
Expose the existing Workspace.getHomeDir command through renderer-worker IPC so other workers can format user-facing paths.