### PR TITLE
fix: improve missing resize warning

### DIFF
--- a/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
+++ b/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
@@ -249,8 +249,13 @@ export const resize = async (id, dimensions) => {
   Assert.number(id)
   Assert.object(dimensions)
   const instance = ViewletStates.getInstance(id)
-  if (!instance || !instance.factory || !instance.factory.resize) {
-    console.warn('cannot resize', id)
+  if (!instance) {
+    console.warn(`Cannot resize component instance ${id}: instance not found`)
+    return []
+  }
+  if (!instance.factory || !instance.factory.resize) {
+    const componentName = instance.factory?.name || instance.moduleId || id
+    console.warn(`The "${componentName}" component is missing a resize function`)
     return []
   }
   const oldState = instance.state

--- a/packages/renderer-worker/test/Viewlet.test.js
+++ b/packages/renderer-worker/test/Viewlet.test.js
@@ -58,6 +58,42 @@ test.skip('setState - shouldApplyNewState returns false', () => {
   // }
 })
 
+test('resize - missing resize function', async () => {
+  const spy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  ViewletStates.set(2, {
+    state: { uid: 2 },
+    renderedState: { uid: 2 },
+    moduleId: 'ProcessExplorer',
+    factory: { name: 'Process Explorer' },
+  })
+
+  const result = await Viewlet.resize(2, {})
+
+  expect(result).toEqual([])
+  expect(spy).toHaveBeenCalledWith('The "Process Explorer" component is missing a resize function')
+  spy.mockRestore()
+})
+
+test('resize - missing resize function falls back to module id', async () => {
+  const spy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+  const result = await Viewlet.resize(1, {})
+
+  expect(result).toEqual([])
+  expect(spy).toHaveBeenCalledWith('The "Layout" component is missing a resize function')
+  spy.mockRestore()
+})
+
+test('resize - missing instance', async () => {
+  const spy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+  const result = await Viewlet.resize(2, {})
+
+  expect(result).toEqual([])
+  expect(spy).toHaveBeenCalledWith('Cannot resize component instance 2: instance not found')
+  spy.mockRestore()
+})
+
 test('openWidget - once', async () => {
   // @ts-ignore
   ViewletManager.load.mockImplementation(() => {


### PR DESCRIPTION
Improve resize diagnostics by naming the affected component and distinguish missing instances. Add focused regression coverage for display-name and module-ID fallbacks.