### PR TITLE
fix: improve command not found error

### DIFF
--- a/packages/renderer-worker/src/parts/CommandNotFoundError/CommandNotFoundError.js
+++ b/packages/renderer-worker/src/parts/CommandNotFoundError/CommandNotFoundError.js
@@ -2,7 +2,7 @@ import * as ErrorCodes from '../ErrorCodes/ErrorCodes.js'
 
 export class CommandNotFoundError extends Error {
   constructor(id) {
-    super(`Command "${id}" not found (renderer worker)`)
+    super(`command ${id} not found`)
     this.name = 'CommandNotFoundError'
     this.code = ErrorCodes.E_COMMAND_NOT_FOUND
   }

--- a/packages/renderer-worker/src/parts/ModuleMap/ModuleMap.js
+++ b/packages/renderer-worker/src/parts/ModuleMap/ModuleMap.js
@@ -233,6 +233,6 @@ export const getModuleId = (commandId) => {
     case 'Markdown':
       return ModuleId.Markdown
     default:
-      throw new Error(`module ${prefix} not found`)
+      throw new CommandNotFoundError(commandId)
   }
 }

--- a/packages/renderer-worker/test/ModuleMap.test.js
+++ b/packages/renderer-worker/test/ModuleMap.test.js
@@ -1,9 +1,12 @@
 import { expect, test } from '@jest/globals'
+import { CommandNotFoundError } from '../src/parts/CommandNotFoundError/CommandNotFoundError.js'
 import * as ModuleId from '../src/parts/ModuleId/ModuleId.js'
 import * as ModuleMap from '../src/parts/ModuleMap/ModuleMap.js'
 
 test('getModule - not found', () => {
-  expect(() => ModuleMap.getModuleId('NotFound.command')).toThrow(new Error('module NotFound not found'))
+  const getModuleId = () => ModuleMap.getModuleId('Layout.getModuleId')
+  expect(getModuleId).toThrow(CommandNotFoundError)
+  expect(getModuleId).toThrow(new Error('command Layout.getModuleId not found'))
 })
 
 test('getModule', () => {


### PR DESCRIPTION
Summary:
- report the full command ID when no renderer module matches
- use the typed command-not-found error consistently
- cover the Layout.getModuleId failure case