### PR TITLE
feature: pass extension sidebar parent uid

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletExtensions/ViewletExtensions.js
+++ b/packages/renderer-worker/src/parts/ViewletExtensions/ViewletExtensions.js
@@ -9,7 +9,7 @@ export const saveState = async (state) => {
   return savedState
 }
 
-export const create = (id, uri, x, y, width, height) => {
+export const create = (id, uri, x, y, width, height, _args, parentUid) => {
   return {
     id,
     uid: id,
@@ -20,6 +20,7 @@ export const create = (id, uri, x, y, width, height) => {
     y,
     platform: Platform.platform,
     assetDir: AssetDir.assetDir,
+    parentUid,
   }
 }
 
@@ -34,6 +35,7 @@ export const loadContent = async (state, savedState) => {
     state.height,
     state.platform,
     state.assetDir,
+    state.parentUid,
   )
 
   await ExtensionSearchViewWorker.invoke('SearchExtensions.loadContent', state.id, savedState)
@@ -73,6 +75,7 @@ export const hotReload = async (state) => {
     state.height,
     state.platform,
     state.assetDir,
+    state.parentUid,
   )
   await ExtensionSearchViewWorker.invoke('SearchExtensions.loadContent', state.id, savedState)
   const diffResult = await ExtensionSearchViewWorker.invoke('SearchExtensions.diff2', state.id)

--- a/packages/renderer-worker/test/ViewletExtensions.test.js
+++ b/packages/renderer-worker/test/ViewletExtensions.test.js
@@ -1,0 +1,7 @@
+import { expect, test } from '@jest/globals'
+import * as ViewletExtensions from '../src/parts/ViewletExtensions/ViewletExtensions.js'
+
+test('create stores the parent uid', () => {
+  const state = ViewletExtensions.create(1, '', 0, 0, 100, 100, [], 42)
+  expect(state.parentUid).toBe(42)
+})


### PR DESCRIPTION
Passes the Extensions sidebar parent UID into the extension search worker so dynamic search titles can use the existing sidebar title command.