### PR TITLE
feature: add open license command

### DIFF
--- a/packages/renderer-worker/src/parts/GetLicenseUri/GetLicenseUri.js
+++ b/packages/renderer-worker/src/parts/GetLicenseUri/GetLicenseUri.js
@@ -1,0 +1,12 @@
+import * as AssetDir from '../AssetDir/AssetDir.js'
+import * as Platform from '../Platform/Platform.js'
+import * as PlatformType from '../PlatformType/PlatformType.js'
+import * as SharedProcess from '../SharedProcess/SharedProcess.js'
+
+export const getLicenseUri = async (platform = Platform.platform, assetDir = AssetDir.assetDir) => {
+  if (platform === PlatformType.Web) {
+    return `${assetDir}/LICENSE`
+  }
+  const rootUri = await SharedProcess.invoke('Platform.getRootUri')
+  return `${rootUri.replace(/\/$/, '')}/LICENSE`
+}

--- a/packages/renderer-worker/src/parts/License/License.ipc.js
+++ b/packages/renderer-worker/src/parts/License/License.ipc.js
@@ -1,0 +1,7 @@
+import * as License from './License.js'
+
+export const name = 'License'
+
+export const Commands = {
+  openLicense: License.openLicense,
+}

--- a/packages/renderer-worker/src/parts/License/License.js
+++ b/packages/renderer-worker/src/parts/License/License.js
@@ -1,0 +1,7 @@
+import * as GetLicenseUri from '../GetLicenseUri/GetLicenseUri.js'
+import * as OpenUri from '../OpenUri/OpenUri.js'
+
+export const openLicense = async () => {
+  const uri = await GetLicenseUri.getLicenseUri()
+  await OpenUri.openUri(uri)
+}

--- a/packages/renderer-worker/src/parts/Module/Module.js
+++ b/packages/renderer-worker/src/parts/Module/Module.js
@@ -59,6 +59,7 @@ import * as IpcParent from '../IpcParent/IpcParent.ipc.js'
 import * as KeyBindings from '../KeyBindings/KeyBindings.ipc.js'
 import * as KeyBindingsInitial from '../KeyBindingsInitial/KeyBindingsInitial.ipc.js'
 import * as Languages from '../Languages/Languages.ipc.js'
+import * as License from '../License/License.ipc.js'
 import * as Listener from '../Listener/Listener.ipc.js'
 import * as LocalStorage from '../LocalStorage/LocalStorage.ipc.js'
 import * as Markdown from '../Markdown/Markdown.ipc.js'
@@ -185,6 +186,8 @@ export const load = (moduleId) => {
       return KeyBindings
     case ModuleId.KeyBindingsInitial:
       return KeyBindingsInitial
+    case ModuleId.License:
+      return License
     case ModuleId.Listener:
       return Listener
     case ModuleId.LocalStorage:

--- a/packages/renderer-worker/src/parts/ModuleId/ModuleId.js
+++ b/packages/renderer-worker/src/parts/ModuleId/ModuleId.js
@@ -106,3 +106,4 @@ export const Markdown = 138
 export const FileSystemHandle = 139
 export const MouseActions = 140
 export const Timeout = 141
+export const License = 142

--- a/packages/renderer-worker/src/parts/ModuleMap/ModuleMap.js
+++ b/packages/renderer-worker/src/parts/ModuleMap/ModuleMap.js
@@ -188,6 +188,8 @@ export const getModuleId = (commandId) => {
       return ModuleId.OffscreenCanvas
     case 'Languages':
       return ModuleId.Languages
+    case 'License':
+      return ModuleId.License
     case 'FileWatcher':
       return ModuleId.FileWatcher
     case 'ExtensionHostTypeDefinition':

--- a/packages/renderer-worker/test/GetLicenseUri.test.js
+++ b/packages/renderer-worker/test/GetLicenseUri.test.js
@@ -1,0 +1,37 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import * as PlatformType from '../src/parts/PlatformType/PlatformType.js'
+
+jest.unstable_mockModule('../src/parts/SharedProcess/SharedProcess.js', () => ({
+  invoke: jest.fn(() => {
+    throw new Error('not implemented')
+  }),
+}))
+
+const SharedProcess = await import('../src/parts/SharedProcess/SharedProcess.js')
+const GetLicenseUri = await import('../src/parts/GetLicenseUri/GetLicenseUri.js')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('web', async () => {
+  const uri = await GetLicenseUri.getLicenseUri(PlatformType.Web, '/abc123')
+  expect(uri).toBe('/abc123/LICENSE')
+  expect(SharedProcess.invoke).not.toHaveBeenCalled()
+})
+
+test('electron', async () => {
+  // @ts-ignore
+  SharedProcess.invoke.mockResolvedValue('file:///opt/lvce-editor')
+  const uri = await GetLicenseUri.getLicenseUri(PlatformType.Electron, '')
+  expect(uri).toBe('file:///opt/lvce-editor/LICENSE')
+  expect(SharedProcess.invoke).toHaveBeenCalledWith('Platform.getRootUri')
+})
+
+test('remote', async () => {
+  // @ts-ignore
+  SharedProcess.invoke.mockResolvedValue('file:///home/test/lvce-editor/')
+  const uri = await GetLicenseUri.getLicenseUri(PlatformType.Remote, '')
+  expect(uri).toBe('file:///home/test/lvce-editor/LICENSE')
+  expect(SharedProcess.invoke).toHaveBeenCalledWith('Platform.getRootUri')
+})

--- a/packages/renderer-worker/test/License.test.js
+++ b/packages/renderer-worker/test/License.test.js
@@ -1,0 +1,19 @@
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/GetLicenseUri/GetLicenseUri.js', () => ({
+  getLicenseUri: jest.fn(() => 'file:///test/LICENSE'),
+}))
+
+jest.unstable_mockModule('../src/parts/OpenUri/OpenUri.js', () => ({
+  openUri: jest.fn(),
+}))
+
+const GetLicenseUri = await import('../src/parts/GetLicenseUri/GetLicenseUri.js')
+const OpenUri = await import('../src/parts/OpenUri/OpenUri.js')
+const License = await import('../src/parts/License/License.js')
+
+test('openLicense', async () => {
+  await License.openLicense()
+  expect(GetLicenseUri.getLicenseUri).toHaveBeenCalledTimes(1)
+  expect(OpenUri.openUri).toHaveBeenCalledWith('file:///test/LICENSE')
+})

--- a/packages/renderer-worker/test/ModuleMap.test.js
+++ b/packages/renderer-worker/test/ModuleMap.test.js
@@ -11,4 +11,5 @@ test('getModule - not found', () => {
 
 test('getModule', () => {
   expect(ModuleMap.getModuleId('About.showAbout')).toBe(ModuleId.About)
+  expect(ModuleMap.getModuleId('License.openLicense')).toBe(ModuleId.License)
 })


### PR DESCRIPTION
Adds a renderer command that resolves the application license URI across web, Electron, and remote environments and opens it in the main area.