### PR TITLE
fix: await viewlet disposal

### DIFF
--- a/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
+++ b/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
@@ -116,7 +116,7 @@ export const dispose = async (id) => {
     if (!instance.factory) {
       throw new Error(`${id} is missing a factory function`)
     }
-    instance.factory.dispose(instance.state)
+    await instance.factory.dispose(instance.state)
     await RendererProcess.invoke(/* Viewlet.dispose */ 'Viewlet.dispose', /* id */ instanceUid)
     if (instance.factory.getKeyBindings) {
       KeyBindingsState.removeKeyBindings(instanceUid)

--- a/packages/renderer-worker/test/Viewlet.test.js
+++ b/packages/renderer-worker/test/Viewlet.test.js
@@ -94,6 +94,38 @@ test('resize - missing instance', async () => {
   spy.mockRestore()
 })
 
+test('dispose - waits for factory disposal before disposing the rendered viewlet', async () => {
+  let resolveDispose = () => {}
+  const disposePromise = new Promise((resolve) => {
+    resolveDispose = () => resolve(undefined)
+  })
+  const factoryDispose = jest.fn((_state) => disposePromise)
+  ViewletStates.set(2, {
+    state: { uid: 2 },
+    renderedState: { uid: 2 },
+    moduleId: 'SimpleBrowser',
+    factory: { dispose: factoryDispose },
+  })
+  // @ts-ignore
+  RendererProcess.invoke.mockImplementation(() => {})
+
+  let didDispose = false
+  const viewletDisposePromise = Viewlet.dispose(2).then(() => {
+    didDispose = true
+  })
+
+  await Promise.resolve()
+  expect(factoryDispose).toHaveBeenCalledWith({ uid: 2 })
+  expect(RendererProcess.invoke).not.toHaveBeenCalled()
+  expect(didDispose).toBe(false)
+
+  resolveDispose()
+  await viewletDisposePromise
+
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.dispose', 2)
+  expect(didDispose).toBe(true)
+})
+
 test('openWidget - once', async () => {
   // @ts-ignore
   ViewletManager.load.mockImplementation(() => {


### PR DESCRIPTION
Await each view factory's async dispose function before removing its rendered viewlet, ensuring WebContentsView cleanup completes.