### PR TITLE
feature: add electron prompt mode

### DIFF
--- a/packages/renderer-worker/src/parts/Exit/Exit.js
+++ b/packages/renderer-worker/src/parts/Exit/Exit.js
@@ -1,5 +1,8 @@
 import * as SharedProcess from '../SharedProcess/SharedProcess.js'
 
-export const exit = () => {
-  return SharedProcess.invoke('Exit.exit')
+export const exit = (code) => {
+  if (code === undefined) {
+    return SharedProcess.invoke('Exit.exit')
+  }
+  return SharedProcess.invoke('Exit.exit', code)
 }

--- a/packages/renderer-worker/src/parts/Process/Process.ipc.js
+++ b/packages/renderer-worker/src/parts/Process/Process.ipc.js
@@ -3,8 +3,11 @@ import * as Process from './Process.js'
 export const name = 'Process'
 
 export const Commands = {
+  getArgv: Process.getArgv,
   getNodeVersion: Process.getNodeVersion,
   getElectronVersion: Process.getElectronVersion,
   getChromeVersion: Process.getChromeVersion,
   getV8Version: Process.getV8Version,
+  writeStderr: Process.writeStderr,
+  writeStdout: Process.writeStdout,
 }

--- a/packages/renderer-worker/src/parts/Process/Process.js
+++ b/packages/renderer-worker/src/parts/Process/Process.js
@@ -41,3 +41,15 @@ export const getDate = () => {
 export const getArch = () => {
   return SharedProcess.invoke('Process.getArch')
 }
+
+export const getArgv = () => {
+  return SharedProcess.invoke('ElectronProcess.getArgv')
+}
+
+export const writeStderr = (value) => {
+  return SharedProcess.invoke('ElectronProcess.writeStderr', value)
+}
+
+export const writeStdout = (value) => {
+  return SharedProcess.invoke('ElectronProcess.writeStdout', value)
+}

--- a/packages/renderer-worker/src/parts/PromptMode/PromptMode.js
+++ b/packages/renderer-worker/src/parts/PromptMode/PromptMode.js
@@ -1,0 +1,62 @@
+import * as Command from '../Command/Command.js'
+import * as Exit from '../Exit/Exit.js'
+import * as Process from '../Process/Process.js'
+
+const promptFlag = '--prompt'
+const promptWithValuePrefix = `${promptFlag}=`
+
+export const parsePrompt = (argv) => {
+  for (let index = 1; index < argv.length; index++) {
+    const argument = argv[index]
+    if (argument === promptFlag) {
+      return typeof argv[index + 1] === 'string' ? argv[index + 1] : ''
+    }
+    if (typeof argument === 'string' && argument.startsWith(promptWithValuePrefix)) {
+      return argument.slice(promptWithValuePrefix.length)
+    }
+  }
+  return undefined
+}
+
+export const getPrompt = async () => {
+  const argv = await Process.getArgv()
+  return parsePrompt(argv)
+}
+
+const getFinalAssistantMessage = (task) => {
+  if (!task || !Array.isArray(task.events)) {
+    return ''
+  }
+  for (let index = task.events.length - 1; index >= 0; index--) {
+    const event = task.events[index]
+    if (event?.type === 'assistant-message' && typeof event.text === 'string') {
+      return event.text
+    }
+  }
+  return ''
+}
+
+const getErrorMessage = (error) => {
+  if (error instanceof Error) {
+    return error.message
+  }
+  return String(error)
+}
+
+export const run = async (prompt) => {
+  try {
+    if (!prompt.trim()) {
+      throw new TypeError('Prompt must be a non-empty string')
+    }
+    await Command.execute('ExtensionHost.executeCommand', 'chat2.createSession')
+    const task = await Command.execute('ExtensionHost.executeCommand', 'chat2.sendMessage', prompt)
+    const finalMessage = getFinalAssistantMessage(task)
+    if (finalMessage) {
+      await Process.writeStdout(`${finalMessage}\n`)
+    }
+    await Exit.exit(0)
+  } catch (error) {
+    await Process.writeStderr(`${getErrorMessage(error)}\n`)
+    await Exit.exit(1)
+  }
+}

--- a/packages/renderer-worker/src/parts/Workbench/Workbench.js
+++ b/packages/renderer-worker/src/parts/Workbench/Workbench.js
@@ -22,6 +22,7 @@ import * as PerformanceMarkerType from '../PerformanceMarkerType/PerformanceMark
 import * as Platform from '../Platform/Platform.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as Preferences from '../Preferences/Preferences.js'
+import * as PromptMode from '../PromptMode/PromptMode.js'
 import * as RecentlyOpened from '../RecentlyOpened/RecentlyOpened.js'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 import * as SaveState from '../SaveState/SaveState.js'
@@ -125,6 +126,8 @@ export const startup = async () => {
 
   IpcState.setConfig(initData.Config?.shouldLaunchMultipleWorkers)
 
+  const prompt = Platform.platform === PlatformType.Electron ? await PromptMode.getPrompt() : undefined
+
   if (initData.Location.href.includes('?replayId')) {
     const url = new URL(initData.Location.href)
     const replayId = url.searchParams.get('replayId')
@@ -143,7 +146,7 @@ export const startup = async () => {
   Performance.mark(PerformanceMarkerType.DidLoadPreferences)
 
   // TODO only load this if session replay is enabled in preferences
-  if (Preferences.get('sessionReplay.enabled')) {
+  if (prompt === undefined && Preferences.get('sessionReplay.enabled')) {
     Performance.mark(PerformanceMarkerType.WillLoadSessionReplay)
     await SessionReplay.startRecording()
     Performance.mark(PerformanceMarkerType.DidLoadSessionReplay)
@@ -154,6 +157,11 @@ export const startup = async () => {
   Performance.mark(PerformanceMarkerType.WillOpenWorkspace)
   await Workspace.hydrate(initData.Location)
   Performance.mark(PerformanceMarkerType.DidOpenWorkspace)
+
+  if (prompt !== undefined) {
+    await PromptMode.run(prompt)
+    return
+  }
 
   await Focus.hydrate()
 

--- a/packages/renderer-worker/test/PromptMode.test.js
+++ b/packages/renderer-worker/test/PromptMode.test.js
@@ -1,0 +1,74 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/Command/Command.js', () => ({
+  execute: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/Exit/Exit.js', () => ({
+  exit: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/Process/Process.js', () => ({
+  getArgv: jest.fn(),
+  writeStderr: jest.fn(),
+  writeStdout: jest.fn(),
+}))
+
+const Command = await import('../src/parts/Command/Command.js')
+const Exit = await import('../src/parts/Exit/Exit.js')
+const Process = await import('../src/parts/Process/Process.js')
+const PromptMode = await import('../src/parts/PromptMode/PromptMode.js')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('parsePrompt - separate value', () => {
+  expect(PromptMode.parsePrompt(['/usr/bin/lvce', '--prompt', 'Fix the tests'])).toBe('Fix the tests')
+})
+
+test('parsePrompt - equals value', () => {
+  expect(PromptMode.parsePrompt(['/usr/bin/lvce', '--prompt=Fix the tests'])).toBe('Fix the tests')
+})
+
+test('parsePrompt - absent', () => {
+  expect(PromptMode.parsePrompt(['/usr/bin/lvce', '.'])).toBeUndefined()
+})
+
+test('getPrompt - reads the Electron argv', async () => {
+  // @ts-ignore
+  Process.getArgv.mockResolvedValue(['/usr/bin/lvce', '--prompt', 'Fix the tests'])
+  await expect(PromptMode.getPrompt()).resolves.toBe('Fix the tests')
+})
+
+test('run - executes the headless chat and exits successfully', async () => {
+  // @ts-ignore
+  Command.execute.mockResolvedValueOnce('session-1')
+  // @ts-ignore
+  Command.execute.mockResolvedValueOnce({
+    events: [
+      { text: 'Working', type: 'assistant-message' },
+      { status: 'completed', type: 'status' },
+      { text: 'Done', type: 'assistant-message' },
+    ],
+  })
+
+  await PromptMode.run('Fix the tests')
+
+  expect(Command.execute).toHaveBeenNthCalledWith(1, 'ExtensionHost.executeCommand', 'chat2.createSession')
+  expect(Command.execute).toHaveBeenNthCalledWith(2, 'ExtensionHost.executeCommand', 'chat2.sendMessage', 'Fix the tests')
+  expect(Process.writeStdout).toHaveBeenCalledWith('Done\n')
+  expect(Process.writeStderr).not.toHaveBeenCalled()
+  expect(Exit.exit).toHaveBeenCalledWith(0)
+})
+
+test('run - reports failures and exits unsuccessfully', async () => {
+  // @ts-ignore
+  Command.execute.mockRejectedValue(new Error('Model request failed'))
+
+  await PromptMode.run('Fix the tests')
+
+  expect(Process.writeStderr).toHaveBeenCalledWith('Model request failed\n')
+  expect(Process.writeStdout).not.toHaveBeenCalled()
+  expect(Exit.exit).toHaveBeenCalledWith(1)
+})


### PR DESCRIPTION
Adds headless --prompt startup that resolves the workspace, skips layout rendering, runs Chat 2 through extension commands, prints the final response, and exits with an appropriate status.