### PR TITLE
fix: store prompt trace cwd as file uri

### DIFF
--- a/packages/renderer-worker/src/parts/PromptTrace/PromptTrace.js
+++ b/packages/renderer-worker/src/parts/PromptTrace/PromptTrace.js
@@ -5,9 +5,16 @@ const join = (separator, left, right) => {
   return left.endsWith(separator) ? `${left}${right}` : `${left}${separator}${right}`
 }
 
+const toFileUri = (path) => {
+  const normalizedPath = path.replaceAll('\\', '/')
+  const url = new URL('file://')
+  url.pathname = normalizedPath.startsWith('/') ? normalizedPath : `/${normalizedPath}`
+  return url.href
+}
+
 export const create = ({ error, fileSystemAccess, finishedAt, id, prompt, result, startedAt }) => {
   return {
-    cwd: Workspace.getPath(),
+    cwd: toFileUri(Workspace.getPath()),
     ...(error && { error }),
     finishedAt,
     id,
@@ -28,7 +35,7 @@ export const createId = () => {
 }
 
 export const write = async (trace) => {
-  const separator = await FileSystemDisk.getPathSeparator()
+  const separator = '/'
   const directory = join(separator, trace.cwd, '.agent-logs')
   const path = join(separator, directory, `trace-${trace.id}.json`)
   await FileSystemDisk.mkdir(directory)

--- a/packages/renderer-worker/test/PromptTrace.test.js
+++ b/packages/renderer-worker/test/PromptTrace.test.js
@@ -1,7 +1,6 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 
 jest.unstable_mockModule('../src/parts/FileSystem/FileSystemDisk.js', () => ({
-  getPathSeparator: jest.fn(),
   mkdir: jest.fn(),
   writeFile: jest.fn(),
 }))
@@ -17,10 +16,20 @@ const Workspace = await import('../src/parts/Workspace/Workspace.js')
 beforeEach(() => {
   jest.resetAllMocks()
   // @ts-ignore
-  FileSystemDisk.getPathSeparator.mockResolvedValue('/')
-  // @ts-ignore
   Workspace.getPath.mockReturnValue('/workspace')
 })
+
+const createTrace = () => {
+  return PromptTrace.create({
+    error: '',
+    fileSystemAccess: undefined,
+    finishedAt: '',
+    id: '',
+    prompt: '',
+    result: undefined,
+    startedAt: '',
+  })
+}
 
 test('create - creates a Pi-inspired completed trace object', () => {
   const trace = PromptTrace.create({
@@ -42,7 +51,7 @@ test('create - creates a Pi-inspired completed trace object', () => {
   })
 
   expect(trace).toEqual({
-    cwd: '/workspace',
+    cwd: 'file:///workspace',
     finishedAt: '2026-07-14T00:01:00.000Z',
     id: 'trace-id',
     messages: [{ content: 'Fix the tests', role: 'user', timestamp: 1 }],
@@ -63,10 +72,28 @@ test('create - creates a Pi-inspired completed trace object', () => {
   })
 })
 
-test('write - writes formatted JSON below the workspace', async () => {
-  const trace = { cwd: '/workspace', id: 'trace-id' }
+test('create - parses cwd as a file URI', () => {
+  // @ts-ignore
+  Workspace.getPath.mockReturnValue('/workspace/project #1')
 
-  await expect(PromptTrace.write(trace)).resolves.toBe('/workspace/.agent-logs/trace-trace-id.json')
-  expect(FileSystemDisk.mkdir).toHaveBeenCalledWith('/workspace/.agent-logs')
-  expect(FileSystemDisk.writeFile).toHaveBeenCalledWith('/workspace/.agent-logs/trace-trace-id.json', JSON.stringify(trace, null, 2))
+  const trace = createTrace()
+
+  expect(trace.cwd).toBe('file:///workspace/project%20%231')
+})
+
+test('create - parses a Windows cwd as a file URI', () => {
+  // @ts-ignore
+  Workspace.getPath.mockReturnValue('C:\\workspace\\project')
+
+  const trace = createTrace()
+
+  expect(trace.cwd).toBe('file:///C:/workspace/project')
+})
+
+test('write - writes formatted JSON below the workspace', async () => {
+  const trace = { cwd: 'file:///workspace', id: 'trace-id' }
+
+  await expect(PromptTrace.write(trace)).resolves.toBe('file:///workspace/.agent-logs/trace-trace-id.json')
+  expect(FileSystemDisk.mkdir).toHaveBeenCalledWith('file:///workspace/.agent-logs')
+  expect(FileSystemDisk.writeFile).toHaveBeenCalledWith('file:///workspace/.agent-logs/trace-trace-id.json', JSON.stringify(trace, null, 2))
 })


### PR DESCRIPTION
Stores CLI prompt trace cwd values as normalized file URIs and keeps trace output paths URI-safe across platforms.