### PR TITLE
fix: default to slime color theme

### DIFF
--- a/packages/renderer-worker/src/parts/ColorTheme/ColorTheme.js
+++ b/packages/renderer-worker/src/parts/ColorTheme/ColorTheme.js
@@ -44,7 +44,7 @@ const applyColorTheme = async (colorThemeId, watchTheme = true) => {
 }
 
 const getCurrentColorTheme = () => {
-  return state.colorTheme || getPreferredColorTheme() || FALLBACK_COLOR_THEME_ID
+  return state.colorTheme || getPreferredColorTheme()
 }
 
 export const setColorTheme = async (colorThemeId) => {
@@ -69,7 +69,7 @@ export const disablePreviewColorTheme = async () => {
   if (!state.previewColorTheme) {
     return
   }
-  const colorThemeId = state.previewBaseColorTheme || getPreferredColorTheme() || FALLBACK_COLOR_THEME_ID
+  const colorThemeId = state.previewBaseColorTheme || getPreferredColorTheme()
   state.previewBaseColorTheme = ''
   state.previewColorTheme = ''
   state.previewColorThemeJson = ''
@@ -91,8 +91,7 @@ export const watch = async (id) => {
 }
 
 const getPreferredColorTheme = () => {
-  const preferredColorTheme = Preferences.get('workbench.colorTheme')
-  return preferredColorTheme
+  return Preferences.get('workbench.colorTheme') || FALLBACK_COLOR_THEME_ID
 }
 
 export const reload = async () => {
@@ -103,8 +102,7 @@ export const reload = async () => {
 // TODO test this, and also the error case
 // TODO have icon theme, color theme together (maybe)
 export const hydrate = async () => {
-  const preferredColorTheme = getPreferredColorTheme()
-  const colorThemeId = preferredColorTheme || FALLBACK_COLOR_THEME_ID
+  const colorThemeId = getPreferredColorTheme()
   try {
     await applyColorTheme(colorThemeId)
   } catch (error) {

--- a/packages/renderer-worker/test/ColorTheme.test.js
+++ b/packages/renderer-worker/test/ColorTheme.test.js
@@ -37,6 +37,23 @@ const Css = await import('../src/parts/Css/Css.js')
 const GetColorThemeCss = await import('../src/parts/GetColorThemeCss/GetColorThemeCss.js')
 const Preferences = await import('../src/parts/Preferences/Preferences.js')
 
+test('reload applies slime when no color theme is selected', async () => {
+  await ColorTheme.reload()
+
+  expect(ColorTheme.state.colorTheme).toBe('slime')
+  expect(GetColorThemeCss.getColorThemeCss).toHaveBeenCalledWith('slime')
+  expect(Css.addCssStyleSheet).toHaveBeenCalledWith('ContributedColorTheme', ':root { --theme-id: "slime"; }')
+})
+
+test('reload applies the selected color theme', async () => {
+  Preferences.state['workbench.colorTheme'] = 'base-theme'
+
+  await ColorTheme.reload()
+
+  expect(ColorTheme.state.colorTheme).toBe('base-theme')
+  expect(GetColorThemeCss.getColorThemeCss).toHaveBeenCalledWith('base-theme')
+})
+
 test('previewColorTheme applies preview without changing preference', async () => {
   Preferences.state['workbench.colorTheme'] = 'base-theme'
   ColorTheme.state.colorTheme = 'base-theme'


### PR DESCRIPTION
Default an absent color-theme preference to the built-in slime theme across reload and startup paths. Add regression coverage for reloads with and without a selected theme.