### PR TITLE
feature: dispose idle view workers

### DIFF
--- a/packages/renderer-worker/src/parts/ExtensionSearchViewWorker/ExtensionSearchViewWorker.js
+++ b/packages/renderer-worker/src/parts/ExtensionSearchViewWorker/ExtensionSearchViewWorker.js
@@ -1,6 +1,9 @@
 import * as GetOrCreateWorker from '../GetOrCreateWorker/GetOrCreateWorker.js'
 import * as LaunchExtensionSearchViewWorker from '../LaunchExtensionSearchViewWorker/LaunchExtensionSearchViewWorker.js'
 
-const { invoke, invokeAndTransfer, restart } = GetOrCreateWorker.getOrCreateWorker(LaunchExtensionSearchViewWorker.launchExtensionSearchViewWorker)
+const { acquire, invoke, invokeAndTransfer, release, restart } = GetOrCreateWorker.getOrCreateWorker(
+  LaunchExtensionSearchViewWorker.launchExtensionSearchViewWorker,
+  'SearchExtensions.terminate',
+)
 
-export { invoke, invokeAndTransfer, restart }
+export { acquire, invoke, invokeAndTransfer, release, restart }

--- a/packages/renderer-worker/src/parts/GetOrCreateWorker/GetOrCreateWorker.js
+++ b/packages/renderer-worker/src/parts/GetOrCreateWorker/GetOrCreateWorker.js
@@ -9,28 +9,67 @@ const getOrCreate = (fn) => {
   return workers.get(fn)
 }
 
-export const getOrCreateWorker = (fn) => {
-  return {
-    async invoke(method, ...params) {
+const terminate = async (fn, terminateCommand) => {
+  const promise = workers.get(fn)
+  if (!promise) {
+    return
+  }
+  workers.delete(fn)
+  const ipc = await promise
+  ipc.send({ jsonrpc: '2.0', method: terminateCommand, params: [] })
+  ipc.dispose()
+}
+
+export const getOrCreateWorker = (fn, terminateCommand) => {
+  let referenceCount = 0
+  let pendingInvocationCount = 0
+
+  const terminateIfIdle = async () => {
+    if (!terminateCommand || referenceCount > 0 || pendingInvocationCount > 0) {
+      return
+    }
+    await terminate(fn, terminateCommand)
+  }
+
+  const invokeWithTracking = async (invokeFn, method, params) => {
+    pendingInvocationCount++
+    try {
       const ipc = await getOrCreate(fn)
-      return JsonRpc.invoke(ipc, method, ...params)
+      return await invokeFn(ipc, method, ...params)
+    } finally {
+      pendingInvocationCount--
+      await terminateIfIdle()
+    }
+  }
+
+  return {
+    acquire() {
+      referenceCount++
+    },
+    async invoke(method, ...params) {
+      return invokeWithTracking(JsonRpc.invoke, method, params)
     },
     async invokeAndTransfer(method, ...params) {
-      const ipc = await getOrCreate(fn)
-      return JsonRpc.invokeAndTransfer(ipc, method, ...params)
+      return invokeWithTracking(JsonRpc.invokeAndTransfer, method, params)
+    },
+    async release() {
+      if (referenceCount === 0) {
+        return
+      }
+      referenceCount--
+      await terminateIfIdle()
     },
     async dispose() {
       const promise = workers.get(fn)
+      if (!promise) {
+        return
+      }
       workers.delete(fn)
       const ipc = await promise
       ipc.dispose()
     },
-    async restart(terminateCommand) {
-      const promise = workers.get(fn)
-      workers.delete(fn)
-      const ipc = await promise
-      ipc.send({ jsonrpc: '2.0', method: terminateCommand, params: [] })
-      ipc.dispose()
+    async restart(restartTerminateCommand) {
+      await terminate(fn, restartTerminateCommand)
       await getOrCreate(fn)
     },
   }

--- a/packages/renderer-worker/src/parts/KeyBindingsViewWorker/KeyBindingsViewWorker.js
+++ b/packages/renderer-worker/src/parts/KeyBindingsViewWorker/KeyBindingsViewWorker.js
@@ -1,6 +1,9 @@
 import * as GetOrCreateWorker from '../GetOrCreateWorker/GetOrCreateWorker.js'
 import * as LaunchKeyBindingsViewWorker from '../LaunchKeyBindingsViewWorker/LaunchKeyBindingsViewWorker.js'
 
-const { invoke, invokeAndTransfer, restart } = GetOrCreateWorker.getOrCreateWorker(LaunchKeyBindingsViewWorker.launchKeyBindingsViewWorker)
+const { acquire, invoke, invokeAndTransfer, release, restart } = GetOrCreateWorker.getOrCreateWorker(
+  LaunchKeyBindingsViewWorker.launchKeyBindingsViewWorker,
+  'KeyBindings.terminate',
+)
 
-export { invoke, invokeAndTransfer, restart }
+export { acquire, invoke, invokeAndTransfer, release, restart }

--- a/packages/renderer-worker/src/parts/ViewletExtensions/ViewletExtensions.js
+++ b/packages/renderer-worker/src/parts/ViewletExtensions/ViewletExtensions.js
@@ -10,6 +10,7 @@ export const saveState = async (state) => {
 }
 
 export const create = (id, uri, x, y, width, height, _args, parentUid) => {
+  ExtensionSearchViewWorker.acquire()
   return {
     id,
     uid: id,
@@ -47,7 +48,9 @@ export const loadContent = async (state, savedState) => {
   }
 }
 
-export const dispose = () => {}
+export const dispose = () => {
+  return ExtensionSearchViewWorker.release()
+}
 
 // TODO lazyload this
 

--- a/packages/renderer-worker/src/parts/ViewletKeyBindings/ViewletKeyBindings.js
+++ b/packages/renderer-worker/src/parts/ViewletKeyBindings/ViewletKeyBindings.js
@@ -7,6 +7,7 @@ import * as KeyBindingsViewWorker from '../KeyBindingsViewWorker/KeyBindingsView
 // TODO make this an extension that can create virtual dom in a webworker
 
 export const create = (id, uri, x, y, width, height) => {
+  KeyBindingsViewWorker.acquire()
   return {
     x,
     y,
@@ -14,6 +15,10 @@ export const create = (id, uri, x, y, width, height) => {
     height,
     uid: id,
   }
+}
+
+export const dispose = () => {
+  return KeyBindingsViewWorker.release()
 }
 
 export const saveState = (state) => {

--- a/packages/renderer-worker/test/GetOrCreateWorker.test.js
+++ b/packages/renderer-worker/test/GetOrCreateWorker.test.js
@@ -1,0 +1,104 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/JsonRpc/JsonRpc.js', () => ({
+  invoke: jest.fn(),
+  invokeAndTransfer: jest.fn(),
+}))
+
+const JsonRpc = await import('../src/parts/JsonRpc/JsonRpc.js')
+const GetOrCreateWorker = await import('../src/parts/GetOrCreateWorker/GetOrCreateWorker.js')
+const invoke = /** @type {any} */ (JsonRpc.invoke)
+const invokeAndTransfer = /** @type {any} */ (JsonRpc.invokeAndTransfer)
+
+const createIpc = () => ({
+  dispose: jest.fn(),
+  send: jest.fn(),
+})
+
+beforeEach(() => {
+  jest.resetAllMocks()
+  invoke.mockResolvedValue(undefined)
+  invokeAndTransfer.mockResolvedValue(undefined)
+})
+
+test('terminates worker after last reference is released', async () => {
+  const ipc = createIpc()
+  const launch = jest.fn(async () => ipc)
+  const worker = GetOrCreateWorker.getOrCreateWorker(launch, 'Test.terminate')
+
+  worker.acquire()
+  worker.acquire()
+  await worker.invoke('Test.method')
+  await worker.release()
+
+  expect(ipc.send).not.toHaveBeenCalled()
+  expect(ipc.dispose).not.toHaveBeenCalled()
+
+  await worker.release()
+
+  expect(ipc.send).toHaveBeenCalledWith({ jsonrpc: '2.0', method: 'Test.terminate', params: [] })
+  expect(ipc.dispose).toHaveBeenCalledTimes(1)
+})
+
+test('terminates an unreferenced worker after an invocation', async () => {
+  const firstIpc = createIpc()
+  const secondIpc = createIpc()
+  const ipcs = [firstIpc, secondIpc]
+  const launch = jest.fn(async () => ipcs.shift())
+  const worker = GetOrCreateWorker.getOrCreateWorker(launch, 'Test.terminate')
+
+  await worker.invoke('Test.method')
+  await worker.invokeAndTransfer('Test.methodAndTransfer')
+
+  expect(launch).toHaveBeenCalledTimes(2)
+  expect(firstIpc.send).toHaveBeenCalledWith({ jsonrpc: '2.0', method: 'Test.terminate', params: [] })
+  expect(firstIpc.dispose).toHaveBeenCalledTimes(1)
+  expect(secondIpc.send).toHaveBeenCalledWith({ jsonrpc: '2.0', method: 'Test.terminate', params: [] })
+  expect(secondIpc.dispose).toHaveBeenCalledTimes(1)
+})
+
+test('waits for pending invocations before terminating worker', async () => {
+  const ipc = createIpc()
+  const launch = jest.fn(async () => ipc)
+  const worker = GetOrCreateWorker.getOrCreateWorker(launch, 'Test.terminate')
+  /** @type {(value: string) => void} */
+  let resolveInvoke = () => {}
+  invoke.mockImplementation(
+    () =>
+      new Promise((resolve) => {
+        resolveInvoke = resolve
+      }),
+  )
+
+  worker.acquire()
+  const invokePromise = worker.invoke('Test.method')
+  await Promise.resolve()
+  await worker.release()
+
+  expect(ipc.send).not.toHaveBeenCalled()
+  expect(ipc.dispose).not.toHaveBeenCalled()
+
+  resolveInvoke('done')
+  await expect(invokePromise).resolves.toBe('done')
+
+  expect(ipc.send).toHaveBeenCalledWith({ jsonrpc: '2.0', method: 'Test.terminate', params: [] })
+  expect(ipc.dispose).toHaveBeenCalledTimes(1)
+})
+
+test('ignores release without a matching reference', async () => {
+  const ipc = createIpc()
+  const launch = jest.fn(async () => ipc)
+  const worker = GetOrCreateWorker.getOrCreateWorker(launch, 'Test.terminate')
+
+  await worker.release()
+  worker.acquire()
+  await worker.invoke('Test.method')
+
+  expect(ipc.send).not.toHaveBeenCalled()
+  expect(ipc.dispose).not.toHaveBeenCalled()
+
+  await worker.release()
+
+  expect(ipc.send).toHaveBeenCalledTimes(1)
+  expect(ipc.dispose).toHaveBeenCalledTimes(1)
+})

--- a/packages/renderer-worker/test/ViewletExtensions.test.js
+++ b/packages/renderer-worker/test/ViewletExtensions.test.js
@@ -1,7 +1,27 @@
-import { expect, test } from '@jest/globals'
-import * as ViewletExtensions from '../src/parts/ViewletExtensions/ViewletExtensions.js'
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+jest.unstable_mockModule('../src/parts/ExtensionSearchViewWorker/ExtensionSearchViewWorker.js', () => ({
+  acquire: jest.fn(),
+  invoke: jest.fn(),
+  release: jest.fn(),
+  restart: jest.fn(),
+}))
+
+const ViewletExtensions = await import('../src/parts/ViewletExtensions/ViewletExtensions.js')
+const ExtensionSearchViewWorker = await import('../src/parts/ExtensionSearchViewWorker/ExtensionSearchViewWorker.js')
 
 test('create stores the parent uid', () => {
   const state = ViewletExtensions.create(1, '', 0, 0, 100, 100, [], 42)
   expect(state.parentUid).toBe(42)
+  expect(ExtensionSearchViewWorker.acquire).toHaveBeenCalledTimes(1)
+})
+
+test('dispose releases worker reference', async () => {
+  await ViewletExtensions.dispose()
+
+  expect(ExtensionSearchViewWorker.release).toHaveBeenCalledTimes(1)
 })

--- a/packages/renderer-worker/test/ViewletKeyBindings.test.js
+++ b/packages/renderer-worker/test/ViewletKeyBindings.test.js
@@ -13,11 +13,26 @@ jest.unstable_mockModule('../src/parts/KeyBindingsInitial/KeyBindingsInitial.js'
   }
 })
 
+jest.unstable_mockModule('../src/parts/KeyBindingsViewWorker/KeyBindingsViewWorker.js', () => ({
+  acquire: jest.fn(),
+  invoke: jest.fn(),
+  release: jest.fn(),
+  restart: jest.fn(),
+}))
+
 const ViewletKeyBindings = await import('../src/parts/ViewletKeyBindings/ViewletKeyBindings.js')
 const KeyBindingsInitial = await import('../src/parts/KeyBindingsInitial/KeyBindingsInitial.js')
+const KeyBindingsViewWorker = await import('../src/parts/KeyBindingsViewWorker/KeyBindingsViewWorker.js')
 
 test('create', () => {
   expect(ViewletKeyBindings.create()).toBeDefined()
+  expect(KeyBindingsViewWorker.acquire).toHaveBeenCalledTimes(1)
+})
+
+test('dispose releases worker reference', async () => {
+  await ViewletKeyBindings.dispose()
+
+  expect(KeyBindingsViewWorker.release).toHaveBeenCalledTimes(1)
 })
 
 test.skip('loadContent', async () => {


### PR DESCRIPTION
## Summary

- reference-count keybindings and extension-search view worker ownership
- gracefully ask idle workers to terminate after their final view closes
- defer shutdown until pending renderer RPC calls have settled