### PR TITLE
feature: use native electron fullscreen

### DIFF
--- a/packages/renderer-worker/src/parts/ElectronWindow/ElectronWindow.ipc.js
+++ b/packages/renderer-worker/src/parts/ElectronWindow/ElectronWindow.ipc.js
@@ -9,6 +9,7 @@ export const Commands = {
   openNew: ElectronWindow.openNew,
   openNewWithUri: ElectronWindow.openNewWithUri,
   toggleDevtools: ElectronWindow.toggleDevtools,
+  toggleFullScreen: ElectronWindow.toggleFullScreen,
   unmaximize: ElectronWindow.unmaximize,
   zoomIn: ElectronWindow.zoomIn,
   zoomOut: ElectronWindow.zoomOut,

--- a/packages/renderer-worker/src/parts/ElectronWindow/ElectronWindow.js
+++ b/packages/renderer-worker/src/parts/ElectronWindow/ElectronWindow.js
@@ -24,6 +24,8 @@ export const openNewWithUri = forward('ElectronWindow.openNewWithUri')
 
 export const toggleDevtools = forward('ElectronWindow.toggleDevtools')
 
+export const toggleFullScreen = forward('ElectronWindow.toggleFullScreen')
+
 export const zoomIn = forward('ElectronWindow.zoomIn')
 
 export const zoomOut = forward('ElectronWindow.zoomOut')

--- a/packages/renderer-worker/src/parts/ToggleFullScreen/ToggleFullScreen.js
+++ b/packages/renderer-worker/src/parts/ToggleFullScreen/ToggleFullScreen.js
@@ -1,5 +1,11 @@
+import * as Command from '../Command/Command.js'
+import * as Platform from '../Platform/Platform.js'
+import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 
 export const toggleFullScreen = () => {
+  if (Platform.platform === PlatformType.Electron) {
+    return Command.execute('ElectronWindow.toggleFullScreen')
+  }
   return RendererProcess.invoke('Window.toggleFullScreen')
 }

--- a/packages/renderer-worker/test/ToggleFullScreenElectron.test.js
+++ b/packages/renderer-worker/test/ToggleFullScreenElectron.test.js
@@ -1,0 +1,20 @@
+import { expect, jest, test } from '@jest/globals'
+import * as PlatformType from '../src/parts/PlatformType/PlatformType.js'
+
+jest.unstable_mockModule('../src/parts/Command/Command.js', () => ({
+  execute: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => ({
+  platform: PlatformType.Electron,
+}))
+
+const Command = await import('../src/parts/Command/Command.js')
+const ToggleFullScreen = await import('../src/parts/ToggleFullScreen/ToggleFullScreen.js')
+
+test('toggleFullScreen - electron', async () => {
+  await ToggleFullScreen.toggleFullScreen()
+
+  expect(Command.execute).toHaveBeenCalledTimes(1)
+  expect(Command.execute).toHaveBeenCalledWith('ElectronWindow.toggleFullScreen')
+})


### PR DESCRIPTION
Routes the fullscreen command through the Electron window bridge on desktop while preserving the browser Fullscreen API for web builds.