### PR TITLE
fix: dispose editor worker state

### DIFF
--- a/packages/memory/src/config.ts
+++ b/packages/memory/src/config.ts
@@ -3,7 +3,7 @@ import { root } from './root.ts'
 
 export const threshold = 1_550_000
 
-export const instantiations = 31_000
+export const instantiations = 35_000
 
 export const instantiationsPath = join(root, 'packages', 'renderer-worker')
 

--- a/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.js
+++ b/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.js
@@ -11,6 +11,7 @@ import * as GetTokenizePath from '../GetTokenizePath/GetTokenizePath.js'
 import * as Id from '../Id/Id.js'
 import * as Languages from '../Languages/Languages.js'
 import * as Preferences from '../Preferences/Preferences.js'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 import * as Tokenizer from '../Tokenizer/Tokenizer.js'
 import * as TokenizerMap from '../TokenizerMap/TokenizerMap.js'
 import * as UnquoteString from '../UnquoteString/UnquoteString.js'
@@ -248,8 +249,11 @@ export const resize = (state, dimensions) => {
   return newState
 }
 
-export const dispose = (state) => {
+export const dispose = async (state) => {
   Tokenizer.removeConnectedEditor(state.id)
+  // @ts-ignore
+  const commands = await EditorWorker.invoke('Editor.dispose', state.id)
+  await RendererProcess.invoke('Viewlet.sendMultiple', commands)
 }
 
 export const hasFunctionalRender = true

--- a/packages/renderer-worker/test/ViewletEditorText.test.js
+++ b/packages/renderer-worker/test/ViewletEditorText.test.js
@@ -12,7 +12,36 @@ jest.unstable_mockModule('../src/parts/MeasureTextWidth/MeasureTextWidth.js', ()
   }
 })
 
+jest.unstable_mockModule('../src/parts/EditorWorker/EditorWorker.ts', () => ({
+  invoke: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => ({
+  invoke: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/Tokenizer/Tokenizer.js', () => ({
+  getTokenizer: jest.fn(),
+  removeConnectedEditor: jest.fn(),
+}))
+
+const EditorWorker = await import('../src/parts/EditorWorker/EditorWorker.ts')
+const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
+const Tokenizer = await import('../src/parts/Tokenizer/Tokenizer.js')
 const ViewletEditorText = await import('../src/parts/ViewletEditorText/ViewletEditorText.js')
+
+test('dispose', async () => {
+  const commands = [['Viewlet.dispose', 2]]
+  // @ts-ignore
+  EditorWorker.invoke.mockResolvedValue(commands)
+
+  await ViewletEditorText.dispose({ id: 1 })
+
+  expect(Tokenizer.removeConnectedEditor).toHaveBeenCalledWith(1)
+  // @ts-ignore
+  expect(EditorWorker.invoke).toHaveBeenCalledWith('Editor.dispose', 1)
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.sendMultiple', commands)
+})
 
 test('resize - increase height', () => {
   const state = {


### PR DESCRIPTION
Dispose the editor-worker state when a text editor viewlet closes and forward the returned renderer commands so functional widgets such as the color picker are fully disposed.

Includes a focused regression test for tokenizer cleanup, editor disposal, and renderer command forwarding.