### PR TITLE
fix: route color picker close command

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorTextCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorTextCommands.js
@@ -7,6 +7,7 @@ const ids = [
   'applyEdit',
   'braceCompletion',
   'cancelSelection',
+  'closeColorPicker',
   'closeCodeGenerator',
   'closeCompletion',
   'closeCompletion',

--- a/packages/renderer-worker/test/ViewletEditorTextCommands.test.js
+++ b/packages/renderer-worker/test/ViewletEditorTextCommands.test.js
@@ -1,0 +1,15 @@
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/EditorWorker/EditorWorker.ts', () => ({
+  invoke: jest.fn(),
+}))
+
+const EditorWorker = await import('../src/parts/EditorWorker/EditorWorker.ts')
+const ViewletEditorTextCommands = await import('../src/parts/ViewletEditorText/ViewletEditorTextCommands.js')
+
+test('closeColorPicker', async () => {
+  const editor = { uid: 42 }
+  await ViewletEditorTextCommands.Commands.closeColorPicker(editor)
+  // @ts-ignore Editor worker types are updated after the editor worker release.
+  expect(EditorWorker.invoke).toHaveBeenCalledWith('Editor.closeColorPicker', 42)
+})


### PR DESCRIPTION
Summary:\n- expose closeColorPicker through the renderer editor-command allowlist\n- verify routing to Editor.closeColorPicker\n\nVerification:\n- full renderer-worker test suite passed\n- type-check, lint, and build passed\n- focused routing test passed