### PR TITLE
feature: expose layout menu keybindings

### DIFF
--- a/packages/renderer-worker/src/parts/GetKeyBindingsForCommands/GetKeyBindingsForCommands.js
+++ b/packages/renderer-worker/src/parts/GetKeyBindingsForCommands/GetKeyBindingsForCommands.js
@@ -1,0 +1,12 @@
+import * as GetCommandKeyBinding from '../GetCommandKeyBinding/GetCommandKeyBinding.js'
+import * as ViewletLayoutKeyBindings from '../ViewletLayout/ViewletLayoutKeyBindings.js'
+
+export const getKeyBindingsForCommands = (_state, entries) => {
+  const keyBindings = ViewletLayoutKeyBindings.getKeyBindings()
+  return entries.map((entry) => {
+    const keyBinding = GetCommandKeyBinding.getCommandKeyBinding(keyBindings, entry.command, entry.args)
+    return keyBinding ? keyBinding.key : 0
+  })
+}
+
+getKeyBindingsForCommands.returnValue = true

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
@@ -1,7 +1,10 @@
+import * as GetKeyBindingsForCommands from '../GetKeyBindingsForCommands/GetKeyBindingsForCommands.js'
 import * as ViewletLayout from './ViewletLayout.js'
 
 // prettier-ignore
-export const Commands = {}
+export const Commands = {
+  getKeyBindings: GetKeyBindingsForCommands.getKeyBindingsForCommands,
+}
 
 export const CommandsWithSideEffects = {
   handleSashPointerDown: ViewletLayout.handleSashPointerDown,

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutKeyBindings.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutKeyBindings.js
@@ -222,5 +222,155 @@ export const getKeyBindings = () => {
       command: 'Run And Debug.handleEvaluate',
       when: WhenExpression.FocusDebugInput,
     },
+    {
+      key: KeyCode.F11,
+      command: 'Window.toggleFullScreen',
+    },
+    {
+      key: KeyModifier.CtrlCmd | KeyCode.KeyN,
+      command: 'Main.newFile',
+    },
+    {
+      key: KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyN,
+      command: 'Window.openNew',
+    },
+    {
+      key: KeyModifier.CtrlCmd | KeyCode.KeyO,
+      command: 'Dialog.openFile',
+    },
+    {
+      key: KeyModifier.CtrlCmd | KeyCode.KeyS,
+      command: 'Main.save',
+    },
+    {
+      key: KeyModifier.CtrlCmd | KeyCode.KeyZ,
+      command: 'Editor.undo',
+      when: WhenExpression.FocusEditorText,
+    },
+    {
+      key: KeyModifier.CtrlCmd | KeyCode.KeyY,
+      command: 'Editor.redo',
+      when: WhenExpression.FocusEditorText,
+    },
+    {
+      key: KeyModifier.CtrlCmd | KeyCode.KeyX,
+      command: 'Editor.cut',
+      when: WhenExpression.FocusEditorText,
+    },
+    {
+      key: KeyModifier.CtrlCmd | KeyCode.KeyC,
+      command: 'Editor.copy',
+      when: WhenExpression.FocusEditorText,
+    },
+    {
+      key: KeyModifier.CtrlCmd | KeyCode.KeyV,
+      command: 'Editor.paste',
+      when: WhenExpression.FocusEditorText,
+    },
+    {
+      key: KeyModifier.CtrlCmd | KeyCode.Slash,
+      command: 'Editor.toggleLineComment',
+      when: WhenExpression.FocusEditorText,
+    },
+    {
+      key: KeyModifier.CtrlCmd | KeyCode.KeyA,
+      command: 'Editor.selectAll',
+      when: WhenExpression.FocusEditorText,
+    },
+    {
+      key: KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyD,
+      command: 'Editor.copyLineDown',
+      when: WhenExpression.FocusEditorText,
+    },
+    {
+      key: KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.UpArrow,
+      command: 'Editor.moveLineUp',
+      when: WhenExpression.FocusEditorText,
+    },
+    {
+      key: KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.DownArrow,
+      command: 'Editor.moveLineDown',
+      when: WhenExpression.FocusEditorText,
+    },
+    {
+      key: KeyModifier.Alt | KeyModifier.Shift | KeyCode.UpArrow,
+      command: 'Editor.addCursorAbove',
+      when: WhenExpression.FocusEditorText,
+    },
+    {
+      key: KeyModifier.Alt | KeyModifier.Shift | KeyCode.DownArrow,
+      command: 'Editor.addCursorBelow',
+      when: WhenExpression.FocusEditorText,
+    },
+    {
+      key: KeyModifier.Alt | KeyCode.F3,
+      command: 'Editor.selectAllOccurrences',
+      when: WhenExpression.FocusEditorText,
+    },
+    {
+      key: KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyP,
+      command: 'Command.openCommandPalette',
+    },
+    {
+      key: KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyE,
+      command: 'Explorer.focus',
+    },
+    {
+      key: KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyF,
+      command: 'Search.focus',
+    },
+    {
+      key: KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyG,
+      command: 'SourceControl.focus',
+    },
+    {
+      key: KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyD,
+      command: 'Run.focus',
+    },
+    {
+      key: KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyX,
+      command: 'Extensions.focus',
+    },
+    {
+      key: KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyM,
+      command: 'Problems.toggle',
+    },
+    {
+      key: KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyU,
+      command: 'Output.toggle',
+    },
+    {
+      key: KeyModifier.CtrlCmd | KeyCode.KeyJ,
+      command: 'Layout.togglePanel',
+    },
+    {
+      key: KeyModifier.CtrlCmd | KeyModifier.Alt | KeyCode.KeyB,
+      command: 'Layout.toggleSecondarySideBar',
+    },
+    {
+      key: KeyModifier.CtrlCmd | KeyCode.Numpad0,
+      command: 'Window.zoomReset',
+    },
+    {
+      key: KeyModifier.CtrlCmd | KeyCode.Backslash,
+      command: 'MainArea.splitRight',
+    },
+    {
+      key: KeyModifier.Alt | KeyModifier.Shift | KeyCode.Digit8,
+      command: 'MainArea.flipEditorLayout',
+    },
+    {
+      key: KeyModifier.CtrlCmd | KeyCode.KeyP,
+      command: 'QuickPick.showFile',
+    },
+    {
+      args: ['workspace-symbol'],
+      key: KeyModifier.CtrlCmd | KeyCode.KeyT,
+      command: 'QuickPick.show',
+    },
+    {
+      key: KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyP,
+      command: 'QuickPick.showCommands',
+    },
   ]
 }

--- a/packages/renderer-worker/test/GetKeyBindingsForCommands.test.js
+++ b/packages/renderer-worker/test/GetKeyBindingsForCommands.test.js
@@ -1,0 +1,49 @@
+import { expect, test } from '@jest/globals'
+import * as KeyCode from '../src/parts/KeyCode/KeyCode.js'
+import * as KeyModifier from '../src/parts/KeyModifier/KeyModifier.js'
+import * as GetKeyBindingsForCommands from '../src/parts/GetKeyBindingsForCommands/GetKeyBindingsForCommands.js'
+
+test('getKeyBindingsForCommands - empty', () => {
+  expect(GetKeyBindingsForCommands.getKeyBindingsForCommands({}, [])).toEqual([])
+})
+
+test('getKeyBindingsForCommands - returns keys in entry order', () => {
+  const entries = [
+    {
+      command: 'Main.newFile',
+    },
+    {
+      command: 'Editor.cut',
+    },
+    {
+      command: 'missing',
+    },
+  ]
+
+  expect(GetKeyBindingsForCommands.getKeyBindingsForCommands({}, entries)).toEqual([
+    KeyModifier.CtrlCmd | KeyCode.KeyN,
+    KeyModifier.CtrlCmd | KeyCode.KeyX,
+    0,
+  ])
+})
+
+test('getKeyBindingsForCommands - matches args', () => {
+  const entries = [
+    {
+      args: ['Terminal'],
+      command: 'Layout.togglePanel',
+    },
+    {
+      command: 'Layout.togglePanel',
+    },
+  ]
+
+  expect(GetKeyBindingsForCommands.getKeyBindingsForCommands({}, entries)).toEqual([
+    KeyModifier.CtrlCmd | KeyCode.Backquote,
+    KeyModifier.CtrlCmd | KeyCode.KeyJ,
+  ])
+})
+
+test('getKeyBindingsForCommands is a return value command', () => {
+  expect(GetKeyBindingsForCommands.getKeyBindingsForCommands.returnValue).toBe(true)
+})

--- a/packages/renderer-worker/test/ViewletLayoutKeyBindings.test.js
+++ b/packages/renderer-worker/test/ViewletLayoutKeyBindings.test.js
@@ -1,0 +1,47 @@
+import { expect, test } from '@jest/globals'
+import * as KeyCode from '../src/parts/KeyCode/KeyCode.js'
+import * as KeyModifier from '../src/parts/KeyModifier/KeyModifier.js'
+import * as ViewletLayoutKeyBindings from '../src/parts/ViewletLayout/ViewletLayoutKeyBindings.js'
+
+const getKey = (command, args) => {
+  const keyBinding = ViewletLayoutKeyBindings.getKeyBindings().find((item) => {
+    return item.command === command && JSON.stringify(item.args) === JSON.stringify(args)
+  })
+  return keyBinding?.key
+}
+
+test('getKeyBindings - includes title bar menu commands', () => {
+  expect(getKey('Main.newFile')).toBe(KeyModifier.CtrlCmd | KeyCode.KeyN)
+  expect(getKey('Window.openNew')).toBe(KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyN)
+  expect(getKey('Dialog.openFile')).toBe(KeyModifier.CtrlCmd | KeyCode.KeyO)
+  expect(getKey('Main.save')).toBe(KeyModifier.CtrlCmd | KeyCode.KeyS)
+  expect(getKey('Editor.undo')).toBe(KeyModifier.CtrlCmd | KeyCode.KeyZ)
+  expect(getKey('Editor.redo')).toBe(KeyModifier.CtrlCmd | KeyCode.KeyY)
+  expect(getKey('Editor.cut')).toBe(KeyModifier.CtrlCmd | KeyCode.KeyX)
+  expect(getKey('Editor.copy')).toBe(KeyModifier.CtrlCmd | KeyCode.KeyC)
+  expect(getKey('Editor.paste')).toBe(KeyModifier.CtrlCmd | KeyCode.KeyV)
+  expect(getKey('Editor.selectAll')).toBe(KeyModifier.CtrlCmd | KeyCode.KeyA)
+  expect(getKey('Command.openCommandPalette')).toBe(KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyP)
+  expect(getKey('Explorer.focus')).toBe(KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyE)
+  expect(getKey('Search.focus')).toBe(KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyF)
+  expect(getKey('SourceControl.focus')).toBe(KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyG)
+  expect(getKey('Run.focus')).toBe(KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyD)
+  expect(getKey('Extensions.focus')).toBe(KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyX)
+  expect(getKey('Problems.toggle')).toBe(KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyM)
+  expect(getKey('Output.toggle')).toBe(KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyU)
+  expect(getKey('Layout.togglePanel')).toBe(KeyModifier.CtrlCmd | KeyCode.KeyJ)
+  expect(getKey('Layout.togglePanel', ['Terminal'])).toBe(KeyModifier.CtrlCmd | KeyCode.Backquote)
+  expect(getKey('Layout.toggleSecondarySideBar')).toBe(KeyModifier.CtrlCmd | KeyModifier.Alt | KeyCode.KeyB)
+  expect(getKey('Window.toggleFullScreen')).toBe(KeyCode.F11)
+  expect(getKey('Window.zoomReset')).toBe(KeyModifier.CtrlCmd | KeyCode.Numpad0)
+  expect(getKey('MainArea.splitRight')).toBe(KeyModifier.CtrlCmd | KeyCode.Backslash)
+  expect(getKey('MainArea.flipEditorLayout')).toBe(KeyModifier.Alt | KeyModifier.Shift | KeyCode.Digit8)
+  expect(getKey('QuickPick.showFile')).toBe(KeyModifier.CtrlCmd | KeyCode.KeyP)
+  expect(getKey('QuickPick.show', ['workspace-symbol'])).toBe(KeyModifier.CtrlCmd | KeyCode.KeyT)
+  expect(getKey('QuickPick.showCommands')).toBe(KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyP)
+  expect(getKey('Developer.toggleDeveloperTools')).toBe(KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyI)
+  expect(getKey('QuickPick.showRecent')).toBe(KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyR)
+  expect(getKey('Layout.toggleSideBar')).toBe(KeyModifier.CtrlCmd | KeyCode.KeyB)
+  expect(getKey('Window.zoomIn')).toBe(KeyModifier.CtrlCmd | KeyCode.Equal)
+  expect(getKey('Window.zoomOut')).toBe(KeyModifier.CtrlCmd | KeyCode.Minus)
+})


### PR DESCRIPTION
Summary:
- expose a batched Layout.getKeyBindings command
- centralize menu-relevant top-level shortcuts in layout
- cover command and argument matching