### PR TITLE
fix: notify views after workspace changes

### DIFF
--- a/packages/memory/src/config.ts
+++ b/packages/memory/src/config.ts
@@ -3,7 +3,7 @@ import { root } from './root.ts'
 
 export const threshold = 1_550_000
 
-export const instantiations = 35_000
+export const instantiations = 35_100
 
 export const instantiationsPath = join(root, 'packages', 'renderer-worker')
 

--- a/packages/renderer-worker/src/parts/FileSystem/FileSystem.ipc.js
+++ b/packages/renderer-worker/src/parts/FileSystem/FileSystem.ipc.js
@@ -5,6 +5,7 @@ export const name = 'FileSystem'
 export const Commands = {
   chmod: FileSystem.chmod,
   copy: FileSystem.copy,
+  exists: FileSystem.exists,
   getBlob: FileSystem.getBlob,
   getFolderSize: FileSystem.getFolderSize,
   getPathSeparator: FileSystem.getPathSeparator,

--- a/packages/renderer-worker/src/parts/FileSystem/FileSystem.js
+++ b/packages/renderer-worker/src/parts/FileSystem/FileSystem.js
@@ -1,7 +1,12 @@
 import * as Assert from '../Assert/Assert.ts'
+import * as Command from '../Command/Command.js'
 import * as EncodingType from '../EncodingType/EncodingType.js'
 import * as GetFileSystem from '../GetFileSystem/GetFileSystem.js'
 import * as GetProtocol from '../GetProtocol/GetProtocol.js'
+
+const notifyWorkspaceChanged = async () => {
+  await Command.execute('Layout.handleWorkspaceRefresh')
+}
 
 export const readFile = async (uri, encoding = EncodingType.Utf8) => {
   const protocol = GetProtocol.getProtocol(uri)
@@ -22,6 +27,7 @@ export const remove = async (uri) => {
   const path = GetProtocol.getPath(protocol, uri)
   const fileSystem = await GetFileSystem.getFileSystem(protocol)
   await fileSystem.remove(path)
+  await notifyWorkspaceChanged()
 }
 
 export const rename = async (oldUri, newUri) => {
@@ -30,6 +36,7 @@ export const rename = async (oldUri, newUri) => {
   const newPath = GetProtocol.getPath(protocol, newUri)
   const fileSystem = await GetFileSystem.getFileSystem(protocol)
   await fileSystem.rename(oldPath, newPath)
+  await notifyWorkspaceChanged()
 }
 
 export const mkdir = async (uri) => {
@@ -44,6 +51,7 @@ export const writeFile = async (uri, content, encoding = EncodingType.Utf8) => {
   const path = GetProtocol.getPath(protocol, uri)
   const fileSystem = await GetFileSystem.getFileSystem(protocol)
   await fileSystem.writeFile(path, content, encoding)
+  await notifyWorkspaceChanged()
 }
 
 export const createFile = (uri) => {
@@ -115,6 +123,25 @@ export const stat = async (uri) => {
   const path = GetProtocol.getPath(protocol, uri)
   const fileSystem = await GetFileSystem.getFileSystem(protocol)
   return fileSystem.stat(path)
+}
+
+export const exists = async (uri) => {
+  const protocol = GetProtocol.getProtocol(uri)
+  const path = GetProtocol.getPath(protocol, uri)
+  const fileSystem = await GetFileSystem.getFileSystem(protocol)
+  if (fileSystem.exists) {
+    return fileSystem.exists(path)
+  }
+  try {
+    if (fileSystem.stat) {
+      await fileSystem.stat(path)
+    } else {
+      await fileSystem.readFile(path)
+    }
+    return true
+  } catch {
+    return false
+  }
 }
 
 export const getFolderSize = async (uri) => {

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.js
@@ -221,6 +221,43 @@ export const saveState = (state) => {
   }
 }
 
+const callGlobalEvent = async (state, eventName, ...args) => {
+  const instances = Object.values(ViewletStates.getAllInstances()).filter((instance) => {
+    return instance.factory.Commands && instance.factory.Commands[eventName]
+  })
+  const results = await Promise.all(
+    instances.map(async (instance) => {
+      const oldState = instance.state
+      const newState = await instance.factory.Commands[eventName](oldState, ...args)
+      return {
+        instance,
+        newState,
+        oldState,
+      }
+    }),
+  )
+  const commands = []
+  for (const { instance, newState, oldState } of results) {
+    if (oldState !== newState) {
+      const uid = instance.uid || instance.state.uid
+      Assert.number(uid)
+      commands.push(...ViewletManager.render(instance.factory, instance.renderedState, newState, uid, newState.parentUid))
+      instance.state = newState
+      instance.renderedState = newState
+    }
+  }
+  return {
+    commands,
+    newState: {
+      ...state,
+    },
+  }
+}
+
+export const handleWorkspaceRefresh = async (state) => {
+  return callGlobalEvent(state, 'handleWorkspaceRefresh')
+}
+
 const getSideBarLocationType = () => {
   const location = Preferences.get('workbench.sideBarLocation')
   switch (location) {

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
@@ -7,6 +7,7 @@ export const Commands = {
 }
 
 export const CommandsWithSideEffects = {
+  handleWorkspaceRefresh: ViewletLayout.handleWorkspaceRefresh,
   handleSashPointerDown: ViewletLayout.handleSashPointerDown,
   handleSashPointerUp: ViewletLayout.handleSashPointerUp,
   handleResize: ViewletLayout.handleResize,

--- a/packages/renderer-worker/test/FileSystem.test.js
+++ b/packages/renderer-worker/test/FileSystem.test.js
@@ -1,4 +1,5 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
+import * as Command from '../src/parts/Command/Command.js'
 import * as DirentType from '../src/parts/DirentType/DirentType.js'
 import * as EncodingType from '../src/parts/EncodingType/EncodingType.js'
 import * as FileSystem from '../src/parts/FileSystem/FileSystem.js'
@@ -7,6 +8,8 @@ import * as FileSystemState from '../src/parts/FileSystemState/FileSystemState.j
 const readFile = jest.fn()
 const writeFile = jest.fn()
 const remove = jest.fn()
+const exists = jest.fn()
+const handleWorkspaceRefresh = jest.fn()
 
 FileSystemState.registerAll({
   test() {
@@ -14,12 +17,15 @@ FileSystemState.registerAll({
       readFile,
       writeFile,
       remove,
+      exists,
     }
   },
 })
 
 beforeEach(() => {
   jest.resetAllMocks()
+  Command.state.commands = Object.create(null)
+  Command.register('Layout.handleWorkspaceRefresh', handleWorkspaceRefresh)
 })
 
 test.skip('readFile', async () => {
@@ -40,6 +46,14 @@ test('removeFile', async () => {
   await FileSystem.remove('test://some-file.txt')
   expect(remove).toHaveBeenCalledTimes(1)
   expect(remove).toHaveBeenCalledWith('some-file.txt')
+  expect(handleWorkspaceRefresh).toHaveBeenCalledTimes(1)
+})
+
+test('exists', async () => {
+  exists.mockReturnValue(true)
+
+  await expect(FileSystem.exists('test://some-file.txt')).resolves.toBe(true)
+  expect(exists).toHaveBeenCalledWith('some-file.txt')
 })
 
 test.skip('removeFile - error', async () => {

--- a/packages/renderer-worker/test/ViewletLayoutGlobalEvent.test.js
+++ b/packages/renderer-worker/test/ViewletLayoutGlobalEvent.test.js
@@ -1,0 +1,97 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/ViewletManager/ViewletManager.js', () => {
+  return {
+    render: jest.fn((factory, renderedState, newState) => {
+      // @ts-ignore
+      return [[`render.${newState.uid}`]]
+    }),
+  }
+})
+
+const ViewletLayout = await import('../src/parts/ViewletLayout/ViewletLayout.js')
+const ViewletManager = await import('../src/parts/ViewletManager/ViewletManager.js')
+const ViewletStates = await import('../src/parts/ViewletStates/ViewletStates.js')
+
+beforeEach(() => {
+  ViewletStates.reset()
+  jest.clearAllMocks()
+})
+
+const createDeferred = () => {
+  let resolve = () => {}
+  const promise = new Promise((resolvePromise) => {
+    resolve = () => resolvePromise(undefined)
+  })
+  return {
+    promise,
+    resolve,
+  }
+}
+
+const createInstance = (uid, handler) => {
+  const state = {
+    uid,
+  }
+  return {
+    factory: {
+      Commands: {
+        handleWorkspaceRefresh: handler,
+      },
+    },
+    moduleId: `Test${uid}`,
+    renderedState: state,
+    state,
+  }
+}
+
+test('handleWorkspaceRefresh runs viewlet handlers in parallel', async () => {
+  const calls = []
+  const first = createDeferred()
+  const second = createDeferred()
+  ViewletStates.set(
+    'first',
+    createInstance(1, async (state) => {
+      calls.push('first:start')
+      await first.promise
+      calls.push('first:end')
+      return {
+        ...state,
+        refreshed: true,
+      }
+    }),
+  )
+  ViewletStates.set(
+    'second',
+    createInstance(2, async (state) => {
+      calls.push('second:start')
+      await second.promise
+      calls.push('second:end')
+      return {
+        ...state,
+        refreshed: true,
+      }
+    }),
+  )
+
+  const state = ViewletLayout.create(1)
+  const resultPromise = ViewletLayout.handleWorkspaceRefresh(state)
+
+  expect(calls).toEqual(['first:start', 'second:start'])
+
+  second.resolve()
+  await Promise.resolve()
+  expect(calls).toEqual(['first:start', 'second:start', 'second:end'])
+
+  first.resolve()
+  const result = await resultPromise
+
+  expect(calls).toEqual(['first:start', 'second:start', 'second:end', 'first:end'])
+  expect(ViewletManager.render).toHaveBeenCalledTimes(2)
+  expect(result).toEqual({
+    commands: [['render.1'], ['render.2']],
+    newState: {
+      ...state,
+    },
+  })
+})


### PR DESCRIPTION
Summary:
- notify loaded layout views after filesystem mutations
- expose filesystem existence checks to view workers
- fan out workspace refresh handlers in parallel