### PR TITLE
fix: avoid nested workspace refresh calls

### DIFF
--- a/packages/memory/src/config.ts
+++ b/packages/memory/src/config.ts
@@ -3,7 +3,7 @@ import { root } from './root.ts'
 
 export const threshold = 1_550_000
 
-export const instantiations = 35_100
+export const instantiations = 36_000
 
 export const instantiationsPath = join(root, 'packages', 'renderer-worker')
 

--- a/packages/renderer-worker/src/parts/FileSystem/FileSystem.ipc.js
+++ b/packages/renderer-worker/src/parts/FileSystem/FileSystem.ipc.js
@@ -5,7 +5,6 @@ export const name = 'FileSystem'
 export const Commands = {
   chmod: FileSystem.chmod,
   copy: FileSystem.copy,
-  exists: FileSystem.exists,
   getBlob: FileSystem.getBlob,
   getFolderSize: FileSystem.getFolderSize,
   getPathSeparator: FileSystem.getPathSeparator,

--- a/packages/renderer-worker/src/parts/FileSystem/FileSystem.js
+++ b/packages/renderer-worker/src/parts/FileSystem/FileSystem.js
@@ -4,8 +4,8 @@ import * as EncodingType from '../EncodingType/EncodingType.js'
 import * as GetFileSystem from '../GetFileSystem/GetFileSystem.js'
 import * as GetProtocol from '../GetProtocol/GetProtocol.js'
 
-const notifyWorkspaceChanged = async () => {
-  await Command.execute('Layout.handleWorkspaceRefresh')
+const notifyWorkspaceChanged = async (deletedUris = []) => {
+  await Command.execute('Layout.handleWorkspaceRefresh', deletedUris)
 }
 
 export const readFile = async (uri, encoding = EncodingType.Utf8) => {
@@ -27,7 +27,7 @@ export const remove = async (uri) => {
   const path = GetProtocol.getPath(protocol, uri)
   const fileSystem = await GetFileSystem.getFileSystem(protocol)
   await fileSystem.remove(path)
-  await notifyWorkspaceChanged()
+  await notifyWorkspaceChanged([uri])
 }
 
 export const rename = async (oldUri, newUri) => {
@@ -123,25 +123,6 @@ export const stat = async (uri) => {
   const path = GetProtocol.getPath(protocol, uri)
   const fileSystem = await GetFileSystem.getFileSystem(protocol)
   return fileSystem.stat(path)
-}
-
-export const exists = async (uri) => {
-  const protocol = GetProtocol.getProtocol(uri)
-  const path = GetProtocol.getPath(protocol, uri)
-  const fileSystem = await GetFileSystem.getFileSystem(protocol)
-  if (fileSystem.exists) {
-    return fileSystem.exists(path)
-  }
-  try {
-    if (fileSystem.stat) {
-      await fileSystem.stat(path)
-    } else {
-      await fileSystem.readFile(path)
-    }
-    return true
-  } catch {
-    return false
-  }
 }
 
 export const getFolderSize = async (uri) => {

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.js
@@ -254,8 +254,8 @@ const callGlobalEvent = async (state, eventName, ...args) => {
   }
 }
 
-export const handleWorkspaceRefresh = async (state) => {
-  return callGlobalEvent(state, 'handleWorkspaceRefresh')
+export const handleWorkspaceRefresh = async (state, deletedUris = []) => {
+  return callGlobalEvent(state, 'handleWorkspaceRefresh', deletedUris)
 }
 
 const getSideBarLocationType = () => {

--- a/packages/renderer-worker/test/FileSystem.test.js
+++ b/packages/renderer-worker/test/FileSystem.test.js
@@ -8,7 +8,6 @@ import * as FileSystemState from '../src/parts/FileSystemState/FileSystemState.j
 const readFile = jest.fn()
 const writeFile = jest.fn()
 const remove = jest.fn()
-const exists = jest.fn()
 const handleWorkspaceRefresh = jest.fn()
 
 FileSystemState.registerAll({
@@ -17,7 +16,6 @@ FileSystemState.registerAll({
       readFile,
       writeFile,
       remove,
-      exists,
     }
   },
 })
@@ -46,14 +44,7 @@ test('removeFile', async () => {
   await FileSystem.remove('test://some-file.txt')
   expect(remove).toHaveBeenCalledTimes(1)
   expect(remove).toHaveBeenCalledWith('some-file.txt')
-  expect(handleWorkspaceRefresh).toHaveBeenCalledTimes(1)
-})
-
-test('exists', async () => {
-  exists.mockReturnValue(true)
-
-  await expect(FileSystem.exists('test://some-file.txt')).resolves.toBe(true)
-  expect(exists).toHaveBeenCalledWith('some-file.txt')
+  expect(handleWorkspaceRefresh).toHaveBeenCalledWith(['test://some-file.txt'])
 })
 
 test.skip('removeFile - error', async () => {

--- a/packages/renderer-worker/test/ViewletLayoutGlobalEvent.test.js
+++ b/packages/renderer-worker/test/ViewletLayoutGlobalEvent.test.js
@@ -47,12 +47,14 @@ const createInstance = (uid, handler) => {
 
 test('handleWorkspaceRefresh runs viewlet handlers in parallel', async () => {
   const calls = []
+  const deletedUris = ['/workspace/deleted.ts']
   const first = createDeferred()
   const second = createDeferred()
   ViewletStates.set(
     'first',
-    createInstance(1, async (state) => {
+    createInstance(1, async (state, receivedDeletedUris) => {
       calls.push('first:start')
+      expect(receivedDeletedUris).toBe(deletedUris)
       await first.promise
       calls.push('first:end')
       return {
@@ -63,8 +65,9 @@ test('handleWorkspaceRefresh runs viewlet handlers in parallel', async () => {
   )
   ViewletStates.set(
     'second',
-    createInstance(2, async (state) => {
+    createInstance(2, async (state, receivedDeletedUris) => {
       calls.push('second:start')
+      expect(receivedDeletedUris).toBe(deletedUris)
       await second.promise
       calls.push('second:end')
       return {
@@ -75,7 +78,7 @@ test('handleWorkspaceRefresh runs viewlet handlers in parallel', async () => {
   )
 
   const state = ViewletLayout.create(1)
-  const resultPromise = ViewletLayout.handleWorkspaceRefresh(state)
+  const resultPromise = ViewletLayout.handleWorkspaceRefresh(state, deletedUris)
 
   expect(calls).toEqual(['first:start', 'second:start'])
 


### PR DESCRIPTION
Summary:
- pass deleted file URIs through workspace refresh events
- close matching tabs without re-entering renderer filesystem RPC
- restore the original type-instantiation budget