### PR TITLE
fix: render editor after language change

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorTextCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorTextCommands.js
@@ -1,3 +1,4 @@
+import * as EditorWorker from '../EditorWorker/EditorWorker.ts'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 import * as WrapEditorCommands from '../WrapEditorCommands/WrapEditorCommands.js'
 
@@ -182,7 +183,6 @@ const ids = [
   'setDecorations',
   'setDelta',
   'setDeltaY',
-  'setLanguageId',
   'setSelections',
   'showHover',
   'showHover2',
@@ -202,6 +202,16 @@ const ids = [
 export const Commands = {
   // TODO command to set cursor position
   ...WrapEditorCommands.wrapEditorCommands(ids),
+
+  async setLanguageId(state, languageId, tokenizePath) {
+    // @ts-ignore Editor worker types are updated after the editor worker release.
+    const newState = await EditorWorker.invoke('Editor.setLanguageId', state.uid, languageId, tokenizePath)
+    const commands = await EditorWorker.invoke('Editor.render', state.id)
+    return {
+      ...newState,
+      commands,
+    }
+  },
 
   // TODO
   async showOverlayMessage(state, editor, ...args) {

--- a/packages/renderer-worker/test/ViewletEditorTextCommands.test.js
+++ b/packages/renderer-worker/test/ViewletEditorTextCommands.test.js
@@ -1,4 +1,4 @@
-import { expect, jest, test } from '@jest/globals'
+import { beforeEach, expect, jest, test } from '@jest/globals'
 
 jest.unstable_mockModule('../src/parts/EditorWorker/EditorWorker.ts', () => ({
   invoke: jest.fn(),
@@ -7,9 +7,31 @@ jest.unstable_mockModule('../src/parts/EditorWorker/EditorWorker.ts', () => ({
 const EditorWorker = await import('../src/parts/EditorWorker/EditorWorker.ts')
 const ViewletEditorTextCommands = await import('../src/parts/ViewletEditorText/ViewletEditorTextCommands.js')
 
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
 test('closeColorPicker', async () => {
   const editor = { uid: 42 }
   await ViewletEditorTextCommands.Commands.closeColorPicker(editor)
   // @ts-ignore Editor worker types are updated after the editor worker release.
   expect(EditorWorker.invoke).toHaveBeenCalledWith('Editor.closeColorPicker', 42)
+})
+
+test('setLanguageId renders the updated syntax highlighting', async () => {
+  const editor = { id: 42, uid: 42 }
+  const newState = { id: 42, languageId: 'xyz', uid: 42 }
+  const commands = [['setText', []]]
+  // @ts-ignore
+  EditorWorker.invoke.mockResolvedValueOnce(newState).mockResolvedValueOnce(commands)
+
+  const result = await ViewletEditorTextCommands.Commands.setLanguageId(editor, 'xyz', '/extensions/test/tokenizeXyz.js')
+
+  // @ts-ignore Editor worker types are updated after the editor worker release.
+  expect(EditorWorker.invoke).toHaveBeenNthCalledWith(1, 'Editor.setLanguageId', 42, 'xyz', '/extensions/test/tokenizeXyz.js')
+  expect(EditorWorker.invoke).toHaveBeenNthCalledWith(2, 'Editor.render', 42)
+  expect(result).toEqual({
+    ...newState,
+    commands,
+  })
 })


### PR DESCRIPTION
## Summary
- render editor rows after changing the editor language id
- keep the updated editor state and attach the generated render commands
- add a regression test for the command flow

## Validation
- npm test
- npm run type-check
- npm run lint
- npm run build
- quick-pick language mode browser e2e with the editor and syntax worker changes