### PR TITLE
fix: show debug console session feedback

### DIFF
--- a/packages/renderer-worker/src/parts/DebugConsoleModel/DebugConsoleModel.js
+++ b/packages/renderer-worker/src/parts/DebugConsoleModel/DebugConsoleModel.js
@@ -1,6 +1,7 @@
 import * as Debug from '../Debug/Debug.js'
 import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
 import * as ViewletStates from '../ViewletStates/ViewletStates.js'
+import * as ViewletDebugConsoleStrings from '../ViewletDebugConsole/ViewletDebugConsoleStrings.js'
 
 const formatResult = (result) => {
   if (!result) {
@@ -16,7 +17,7 @@ export const evaluate = async (inputValue) => {
   // TODO don't depend on other component state
   const debugState = ViewletStates.getState(ViewletModuleId.RunAndDebug)
   if (!debugState) {
-    return ''
+    return ViewletDebugConsoleStrings.noActiveDebugSession()
   }
   const { debugId, callFrameId } = debugState
   const result = await Debug.evaluate(debugId, inputValue, callFrameId)

--- a/packages/renderer-worker/src/parts/GetDebugConsoleVirtualDom/GetDebugConsoleVirtualDom.js
+++ b/packages/renderer-worker/src/parts/GetDebugConsoleVirtualDom/GetDebugConsoleVirtualDom.js
@@ -3,7 +3,7 @@ import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEven
 import * as ClassNames from '../ClassNames/ClassNames.js'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.js'
 
-export const getVirtualDom = (textContent) => {
+export const getVirtualDom = (textContent, inputValue) => {
   const dom = []
   dom.push(
     {
@@ -22,6 +22,7 @@ export const getVirtualDom = (textContent) => {
       className: ClassNames.InputBox,
       onInput: DomEventListenerFunctions.HandleInput,
       onFocus: DomEventListenerFunctions.HandleFocus,
+      value: inputValue,
       childCount: 0,
     },
   )

--- a/packages/renderer-worker/src/parts/ViewletDebugConsole/ViewletDebugConsole.js
+++ b/packages/renderer-worker/src/parts/ViewletDebugConsole/ViewletDebugConsole.js
@@ -33,6 +33,7 @@ export const evaluate = async (state) => {
   const result = await DebugConsoleModel.evaluate(inputValue)
   return {
     ...state,
+    inputValue: '',
     text: `${state.text}\n${result}`,
   }
 }

--- a/packages/renderer-worker/src/parts/ViewletDebugConsole/ViewletDebugConsoleRender.js
+++ b/packages/renderer-worker/src/parts/ViewletDebugConsole/ViewletDebugConsoleRender.js
@@ -7,7 +7,7 @@ const renderText = {
     return oldState.text === newState.text
   },
   apply(oldState, newState) {
-    const dom = GetDebugConsoleVirtualDom.getVirtualDom(newState.text)
+    const dom = GetDebugConsoleVirtualDom.getVirtualDom(newState.text, newState.inputValue)
     return ['setDom', dom]
   },
 }

--- a/packages/renderer-worker/src/parts/ViewletDebugConsole/ViewletDebugConsoleStrings.js
+++ b/packages/renderer-worker/src/parts/ViewletDebugConsole/ViewletDebugConsoleStrings.js
@@ -1,0 +1,12 @@
+import * as I18NString from '../I18NString/I18NString.js'
+
+/**
+ * @enum {string}
+ */
+const UiStrings = {
+  NoActiveDebugSession: 'No active debug session. Start debugging to evaluate expressions.',
+}
+
+export const noActiveDebugSession = () => {
+  return I18NString.i18nString(UiStrings.NoActiveDebugSession)
+}

--- a/packages/renderer-worker/test/DebugConsoleModel.test.js
+++ b/packages/renderer-worker/test/DebugConsoleModel.test.js
@@ -1,0 +1,39 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const evaluate = jest.fn()
+const getState = jest.fn()
+
+jest.unstable_mockModule('../src/parts/Debug/Debug.js', () => ({
+  evaluate,
+}))
+
+jest.unstable_mockModule('../src/parts/ViewletStates/ViewletStates.js', () => ({
+  getState,
+}))
+
+const DebugConsoleModel = await import('../src/parts/DebugConsoleModel/DebugConsoleModel.js')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('evaluate explains when there is no active debug session', async () => {
+  getState.mockReturnValue(undefined)
+
+  await expect(DebugConsoleModel.evaluate('1 + 1')).resolves.toBe('No active debug session. Start debugging to evaluate expressions.')
+  expect(evaluate).not.toHaveBeenCalled()
+})
+
+test('evaluate forwards the expression to an active debug session', async () => {
+  getState.mockReturnValue({
+    callFrameId: 'call-frame-1',
+    debugId: 'debug-1',
+  })
+  // @ts-ignore
+  evaluate.mockResolvedValue({
+    description: '2',
+  })
+
+  await expect(DebugConsoleModel.evaluate('1 + 1')).resolves.toBe('2')
+  expect(evaluate).toHaveBeenCalledWith('debug-1', '1 + 1', 'call-frame-1')
+})

--- a/packages/renderer-worker/test/GetDebugConsoleVirtualDom.test.js
+++ b/packages/renderer-worker/test/GetDebugConsoleVirtualDom.test.js
@@ -1,0 +1,10 @@
+import { expect, test } from '@jest/globals'
+import * as GetDebugConsoleVirtualDom from '../src/parts/GetDebugConsoleVirtualDom/GetDebugConsoleVirtualDom.js'
+
+test('getVirtualDom controls the input value', () => {
+  const dom = GetDebugConsoleVirtualDom.getVirtualDom('', '1 + 1')
+
+  expect(dom.at(-1)).toMatchObject({
+    value: '1 + 1',
+  })
+})

--- a/packages/renderer-worker/test/ViewletDebugConsole.test.js
+++ b/packages/renderer-worker/test/ViewletDebugConsole.test.js
@@ -1,5 +1,10 @@
-import { expect, test } from '@jest/globals'
-import * as ViewletDebugConsole from '../src/parts/ViewletDebugConsole/ViewletDebugConsole.js'
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/DebugConsoleModel/DebugConsoleModel.js', () => ({
+  evaluate: jest.fn(() => 'No active debug session. Start debugging to evaluate expressions.'),
+}))
+
+const ViewletDebugConsole = await import('../src/parts/ViewletDebugConsole/ViewletDebugConsole.js')
 
 test('create', () => {
   const state = ViewletDebugConsole.create()
@@ -9,4 +14,16 @@ test('create', () => {
 test('loadContent', async () => {
   const state = ViewletDebugConsole.create()
   expect(await ViewletDebugConsole.loadContent(state)).toMatchObject({})
+})
+
+test('evaluate shows feedback and clears the input', async () => {
+  const state = {
+    ...ViewletDebugConsole.create(),
+    inputValue: '1 + 1',
+    text: '',
+  }
+  expect(await ViewletDebugConsole.evaluate(state)).toMatchObject({
+    inputValue: '',
+    text: '\nNo active debug session. Start debugging to evaluate expressions.',
+  })
 })


### PR DESCRIPTION
When an expression is submitted without a Run and Debug state, show a localized message explaining that an active debug session is required instead of appending an invisible empty result. Submitted input is also cleared and rendered as controlled state.

Regression coverage exercises the no-session model branch, active-session forwarding, console state update, and rendered input value. A browser regression was investigated, but this repository's current test app cannot render the panel (the existing debug-console panel e2e is skipped for the same reason).

Validated locally with the full unit suite (205 suites / 763 tests), type-check, lint, build/static build, baseline e2e, integration command, and memory measurement.