### PR TITLE
feat: dispatch editor folding commands

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorTextCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorTextCommands.js
@@ -84,6 +84,7 @@ const ids = [
   'EditorSourceActions.focusPrevious',
   'EditorSourceActions.selectCurrent',
   'findAllReferences',
+  'fold',
   'FindWidget.close',
   'FindWidget.focusCloseButton',
   'FindWidget.focusFind',
@@ -196,6 +197,7 @@ const ids = [
   'toggleLineComment',
   'type',
   'undo',
+  'unfold',
   'unIndent',
 ]
 

--- a/packages/renderer-worker/test/ViewletEditorTextCommands.test.js
+++ b/packages/renderer-worker/test/ViewletEditorTextCommands.test.js
@@ -18,6 +18,20 @@ test('closeColorPicker', async () => {
   expect(EditorWorker.invoke).toHaveBeenCalledWith('Editor.closeColorPicker', 42)
 })
 
+test('fold', async () => {
+  const editor = { uid: 42 }
+  await ViewletEditorTextCommands.Commands.fold(editor)
+  // @ts-ignore Editor worker types are updated after the editor worker release.
+  expect(EditorWorker.invoke).toHaveBeenCalledWith('Editor.fold', 42)
+})
+
+test('unfold', async () => {
+  const editor = { uid: 42 }
+  await ViewletEditorTextCommands.Commands.unfold(editor)
+  // @ts-ignore Editor worker types are updated after the editor worker release.
+  expect(EditorWorker.invoke).toHaveBeenCalledWith('Editor.unfold', 42)
+})
+
 test('setLanguageId renders the updated syntax highlighting', async () => {
   const editor = { id: 42, uid: 42 }
   const newState = { id: 42, languageId: 'xyz', uid: 42 }


### PR DESCRIPTION
## Summary
- expose renderer dispatch wrappers for `Editor.fold` and `Editor.unfold`
- add regression tests for both worker invocations

This is the renderer-side dependency for the editor code-folding implementation.

## Validation
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run build:static`
- `packages/memory: npm run measure`