### PR TITLE
fix: use registered rename widget commands

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutKeyBindings.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutKeyBindings.js
@@ -12,12 +12,12 @@ export const getKeyBindings = () => {
     },
     {
       key: KeyCode.Enter,
-      command: 'EditorRename.finish',
+      command: 'EditorRename.accept',
       when: WhenExpression.FocusEditorRename,
     },
     {
       key: KeyCode.Escape,
-      command: 'EditorRename.abort',
+      command: 'EditorRename.close',
       when: WhenExpression.FocusEditorRename,
     },
     {

--- a/packages/renderer-worker/test/ViewletLayoutKeyBindings.test.js
+++ b/packages/renderer-worker/test/ViewletLayoutKeyBindings.test.js
@@ -2,6 +2,7 @@ import { expect, test } from '@jest/globals'
 import * as KeyCode from '../src/parts/KeyCode/KeyCode.js'
 import * as KeyModifier from '../src/parts/KeyModifier/KeyModifier.js'
 import * as ViewletLayoutKeyBindings from '../src/parts/ViewletLayout/ViewletLayoutKeyBindings.js'
+import * as WhenExpression from '../src/parts/WhenExpression/WhenExpression.js'
 
 const getKey = (command, args) => {
   const keyBinding = ViewletLayoutKeyBindings.getKeyBindings().find((item) => {
@@ -9,6 +10,25 @@ const getKey = (command, args) => {
   })
   return keyBinding?.key
 }
+
+test('getKeyBindings - rename widget', () => {
+  const keyBindings = ViewletLayoutKeyBindings.getKeyBindings()
+
+  expect(keyBindings).toEqual(
+    expect.arrayContaining([
+      {
+        command: 'EditorRename.accept',
+        key: KeyCode.Enter,
+        when: WhenExpression.FocusEditorRename,
+      },
+      {
+        command: 'EditorRename.close',
+        key: KeyCode.Escape,
+        when: WhenExpression.FocusEditorRename,
+      },
+    ]),
+  )
+})
 
 test('getKeyBindings - includes title bar menu commands', () => {
   expect(getKey('Main.newFile')).toBe(KeyModifier.CtrlCmd | KeyCode.KeyN)


### PR DESCRIPTION
## Summary
- bind Enter to the registered EditorRename.accept command
- bind Escape to the registered EditorRename.close command
- add regression coverage for both rename-widget keybindings

This prevents Enter from falling through to the text editor and inserting a newline while the rename widget is focused.

## Testing
- npm test --workspace packages/renderer-worker -- --runInBand test/ViewletLayoutKeyBindings.test.js
- npm test --workspace packages/renderer-worker -- --runInBand
- npm run type-check
- npm run lint
- npm run build